### PR TITLE
[E1-1] 識別トークン発行ミドルウェア

### DIFF
--- a/apps/api/src/domain/client-identifier.ts
+++ b/apps/api/src/domain/client-identifier.ts
@@ -1,0 +1,41 @@
+/**
+ * ClientIdentifier 値オブジェクト
+ *
+ * 匿名ユーザーの識別ハッシュを表現する。
+ * 生IPは保持せず、SHA-256ハッシュのみを扱う。
+ */
+export class ClientIdentifier {
+  private constructor(readonly hash: string) {}
+
+  /**
+   * SHA-256(IP + Cookie_ID + User-Agent) でクライアント識別子を生成する。
+   * Cookie同意拒否時（cookieId が undefined）は IP + User-Agent のみで生成。
+   *
+   * 注意: 引数の ip は本メソッド内でのみ使用され、外部に露出しない。
+   */
+  static async create(
+    ip: string,
+    userAgent: string,
+    cookieId?: string,
+  ): Promise<ClientIdentifier> {
+    const parts = cookieId ? [ip, cookieId, userAgent] : [ip, userAgent];
+    const raw = parts.join("|");
+
+    const encoder = new TextEncoder();
+    const data = encoder.encode(raw);
+    const digest = await crypto.subtle.digest("SHA-256", data);
+
+    const hashArray = Array.from(new Uint8Array(digest));
+    const hash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+
+    return new ClientIdentifier(hash);
+  }
+
+  toString(): string {
+    return this.hash;
+  }
+
+  equals(other: ClientIdentifier): boolean {
+    return this.hash === other.hash;
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,13 +1,14 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import type { Env } from "./types/env";
+import type { Env, AppVariables } from "./types/env";
+import { identificationMiddleware } from "./middleware/identification";
 import upload from "./routes/upload";
 import convert from "./routes/convert";
 import status from "./routes/status";
 import download from "./routes/download";
 import callback from "./routes/callback";
 
-const app = new Hono<{ Bindings: Env }>();
+const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 // CORS
 app.use(
@@ -28,6 +29,9 @@ app.use(
     return middleware(c, next);
   }
 );
+
+// Identification — CORS の後、ルートの前に適用
+app.use("/api/*", identificationMiddleware());
 
 // Health check
 app.get("/health", (c) => c.json({ status: "ok" }));

--- a/apps/api/src/middleware/identification.ts
+++ b/apps/api/src/middleware/identification.ts
@@ -1,0 +1,39 @@
+import type { MiddlewareHandler } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+import { ClientIdentifier } from "../domain/client-identifier";
+
+const COOKIE_NAME = "qc_sid";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+/**
+ * 識別トークン発行ミドルウェア
+ *
+ * - CF-Connecting-IP, qc_sid Cookie, User-Agent から SHA-256 ハッシュを生成
+ * - 初回アクセス時に qc_sid Cookie（UUID v4）を発行
+ * - Cookie 同意拒否時（qc_sid なし）は IP + UA のみで識別
+ * - 生 IP はどこにも保存・ログ出力しない
+ */
+export const identificationMiddleware = (): MiddlewareHandler => {
+  return async (c, next) => {
+    const ip = c.req.header("cf-connecting-ip") || "unknown";
+    const userAgent = c.req.header("user-agent") || "unknown";
+
+    // 既存の Cookie を取得、なければ新規発行
+    let cookieId = getCookie(c, COOKIE_NAME);
+    if (!cookieId) {
+      cookieId = crypto.randomUUID();
+      setCookie(c, COOKIE_NAME, cookieId, {
+        path: "/",
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+        maxAge: COOKIE_MAX_AGE,
+      });
+    }
+
+    const identifier = await ClientIdentifier.create(ip, userAgent, cookieId);
+    c.set("clientHash", identifier.hash);
+
+    await next();
+  };
+};

--- a/apps/api/src/types/env.ts
+++ b/apps/api/src/types/env.ts
@@ -5,3 +5,7 @@ export interface Env {
   CONVERTER_URL: string;
   CONVERTER_API_KEY: string;
 }
+
+export interface AppVariables {
+  clientHash: string;
+}


### PR DESCRIPTION
## Summary
- Workers ミドルウェアで匿名ユーザーの識別ハッシュ（SHA-256）を生成・付与
- 初回アクセスで `qc_sid` Cookie（UUID v4, Max-Age 30日）を自動発行
- 生IPはハッシュ計算のみに使用し、ログ・DBには一切保存しない

## Changes
- `apps/api/src/domain/client-identifier.ts` — ClientIdentifier 値オブジェクト（SHA-256 生成）
- `apps/api/src/middleware/identification.ts` — 識別ミドルウェア（Cookie 発行 + ハッシュ生成）
- `apps/api/src/index.ts` — CORS の後、ルートの前にミドルウェアを適用
- `apps/api/src/types/env.ts` — AppVariables 型に clientHash を追加

## Test plan
- [ ] `wrangler dev` でローカル起動し、初回アクセスで `qc_sid` Cookie が Set-Cookie で返ること
- [ ] 同一ブラウザ・同一IPで2回アクセスし、同一ハッシュが生成されること
- [ ] IP / Cookie / UA を変えてアクセスし、異なるハッシュになること
- [ ] ログ出力に生IPが含まれていないこと
- [ ] `npx turbo build --filter=@quickconv/api` が成功すること（確認済み）

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)