### PR TITLE
feat(web): add GA4 tracking (E4-7)

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { routing } from "@/lib/i18n/routing";
 import { locales } from "@/lib/i18n/config";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
+import { GoogleAnalytics } from "@/components/google-analytics";
 
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
@@ -36,6 +37,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   return (
     <html lang={locale}>
       <body className="min-h-screen flex flex-col bg-background text-foreground">
+        <GoogleAnalytics />
         <NextIntlClientProvider messages={messages}>
           <Header />
           <main className="flex-1">{children}</main>

--- a/apps/web/src/components/google-analytics.tsx
+++ b/apps/web/src/components/google-analytics.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Script from "next/script";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+function hasConsentAccepted(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return localStorage.getItem("qc_cookie_consent") === "accepted";
+  } catch {
+    return false;
+  }
+}
+
+export function GoogleAnalytics() {
+  const pathname = usePathname();
+  const [consentGiven, setConsentGiven] = useState(false);
+
+  // Check consent on mount and listen for storage changes
+  useEffect(() => {
+    setConsentGiven(hasConsentAccepted());
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === "qc_cookie_consent") {
+        setConsentGiven(e.newValue === "accepted");
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  // Send pageview on SPA navigation
+  useEffect(() => {
+    if (!consentGiven || !GA_MEASUREMENT_ID) return;
+    if (typeof window.gtag !== "function") return;
+
+    window.gtag("config", GA_MEASUREMENT_ID, {
+      page_path: pathname,
+    });
+  }, [pathname, consentGiven]);
+
+  // Don't render anything if no measurement ID or no consent
+  if (!GA_MEASUREMENT_ID || !consentGiven) {
+    return null;
+  }
+
+  const isDebug = process.env.NODE_ENV === "development";
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', {
+            page_path: window.location.pathname,
+            ${isDebug ? "debug_mode: true," : ""}
+          });
+        `}
+      </Script>
+    </>
+  );
+}

--- a/apps/web/src/types/gtag.d.ts
+++ b/apps/web/src/types/gtag.d.ts
@@ -1,0 +1,8 @@
+interface Window {
+  gtag: (
+    command: "config" | "event" | "js" | "set",
+    targetOrDate: string | Date,
+    params?: Record<string, unknown>
+  ) => void;
+  dataLayer: unknown[];
+}


### PR DESCRIPTION
## Summary
- GA4トラッキング（gtag.js）をクライアントコンポーネントとして導入
- Cookie同意（`qc_cookie_consent=accepted`）後にのみGA4が発火
- SPA遷移時のページビュー送信対応（`usePathname` + `useEffect`）
- 測定IDは環境変数 `NEXT_PUBLIC_GA_MEASUREMENT_ID` で管理（ハードコード禁止）
- 開発環境ではdebug_mode有効、未設定時はGA4無効化

## Changed Files
- `apps/web/src/components/google-analytics.tsx` - GA4クライアントコンポーネント（新規）
- `apps/web/src/types/gtag.d.ts` - Window.gtag型定義（新規）
- `apps/web/src/app/[locale]/layout.tsx` - GoogleAnalyticsコンポーネント追加

## Test plan
- [ ] `NEXT_PUBLIC_GA_MEASUREMENT_ID` 未設定時にGA4スクリプトが読み込まれないことを確認
- [ ] `qc_cookie_consent` が `accepted` 以外の時にGA4が発火しないことを確認
- [ ] Cookie同意後にGA4が有効化されることを確認
- [ ] SPAページ遷移時にpageviewが送信されることを確認
- [ ] `npx turbo build --filter=@quickconv/web` でビルドが通ることを確認

Closes #47