### PR TITLE
feat: add cookie consent banner, privacy policy, and terms pages

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { locales } from "@/lib/i18n/config";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { GoogleAnalytics } from "@/components/google-analytics";
+import { CookieConsent } from "@/components/cookie-consent";
 
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
@@ -42,6 +43,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
           <Header />
           <main className="flex-1">{children}</main>
           <Footer />
+          <CookieConsent />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/apps/web/src/app/[locale]/privacy/page.tsx
+++ b/apps/web/src/app/[locale]/privacy/page.tsx
@@ -1,0 +1,101 @@
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { locales } from "@/lib/i18n/config";
+import type { Metadata } from "next";
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "privacyPolicy" });
+  return {
+    title: `${t("title")} | QuickConv`,
+  };
+}
+
+export default async function PrivacyPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("privacyPolicy");
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
+      <p className="mt-2 text-sm text-muted-foreground">{t("lastUpdated")}</p>
+      <p className="mt-6 text-muted-foreground">{t("intro")}</p>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("dataCollectionTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("dataCollectionDescription")}
+        </p>
+        <ul className="mt-2 list-disc list-inside text-muted-foreground space-y-1">
+          <li>{t("dataIpHash")}</li>
+          <li>{t("dataCookieId")}</li>
+          <li>{t("dataUserAgent")}</li>
+        </ul>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("purposeTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("purposeDescription")}
+        </p>
+        <ul className="mt-2 list-disc list-inside text-muted-foreground space-y-1">
+          <li>{t("purposeRateLimit")}</li>
+          <li>{t("purposeServiceImprovement")}</li>
+        </ul>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("retentionTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("retentionDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("thirdPartyTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("thirdPartyDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("cookiesTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("cookiesDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("rightsTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("rightsDescription")}
+        </p>
+        <ul className="mt-2 list-disc list-inside text-muted-foreground space-y-1">
+          <li>{t("rightsAccess")}</li>
+          <li>{t("rightsDelete")}</li>
+          <li>{t("rightsRestrict")}</li>
+        </ul>
+        <p className="mt-2 text-muted-foreground">{t("rightsContact")}</p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("changesTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("changesDescription")}
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/terms/page.tsx
+++ b/apps/web/src/app/[locale]/terms/page.tsx
@@ -1,0 +1,83 @@
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { locales } from "@/lib/i18n/config";
+import type { Metadata } from "next";
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "termsOfService" });
+  return {
+    title: `${t("title")} | QuickConv`,
+  };
+}
+
+export default async function TermsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("termsOfService");
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
+      <p className="mt-2 text-sm text-muted-foreground">{t("lastUpdated")}</p>
+      <p className="mt-6 text-muted-foreground">{t("intro")}</p>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("serviceTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("serviceDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("usageTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">{t("usageDescription")}</p>
+        <ul className="mt-2 list-disc list-inside text-muted-foreground space-y-1">
+          <li>{t("usageLegal")}</li>
+          <li>{t("usageNoMalicious")}</li>
+          <li>{t("usageNoAbuse")}</li>
+          <li>{t("usageComply")}</li>
+        </ul>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("filesTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("filesDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("disclaimerTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("disclaimerDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("limitationTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("limitationDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("changesTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("changesDescription")}
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { Link } from "@/lib/i18n/navigation";
+
+const STORAGE_KEY = "qc_cookie_consent";
+
+export function CookieConsent() {
+  const t = useTranslations("cookieConsent");
+  const tCommon = useTranslations("common");
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem(STORAGE_KEY);
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem(STORAGE_KEY, "accepted");
+    setVisible(false);
+  };
+
+  const handleReject = () => {
+    localStorage.setItem(STORAGE_KEY, "rejected");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background">
+      <div className="max-w-5xl mx-auto px-4 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-muted-foreground">
+          <p>{t("message")}</p>
+          <p className="mt-1">
+            {t.rich("learnMore", {
+              privacyPolicy: (chunks) => (
+                <Link
+                  href="/privacy"
+                  className="underline hover:text-foreground"
+                >
+                  {tCommon("privacyPolicy")}
+                </Link>
+              ),
+            })}
+          </p>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <button
+            onClick={handleReject}
+            className="px-4 py-2 text-sm rounded-md border border-border text-foreground hover:bg-muted transition-colors"
+          >
+            {t("reject")}
+          </button>
+          <button
+            onClick={handleAccept}
+            className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-colors"
+          >
+            {t("accept")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from "next-intl";
+import { Link } from "@/lib/i18n/navigation";
 
 export function Footer() {
   const t = useTranslations("common");
@@ -7,6 +8,15 @@ export function Footer() {
     <footer className="border-t border-border mt-auto">
       <div className="max-w-5xl mx-auto px-4 py-6 text-center">
         <p className="text-xs text-muted-foreground">{t("privacy")}</p>
+        <div className="mt-2 flex items-center justify-center gap-4 text-xs text-muted-foreground">
+          <Link href="/privacy" className="hover:text-foreground transition-colors">
+            {t("privacyPolicy")}
+          </Link>
+          <span aria-hidden="true">|</span>
+          <Link href="/terms" className="hover:text-foreground transition-colors">
+            {t("termsOfService")}
+          </Link>
+        </div>
         <p className="mt-2 text-xs text-muted-foreground">
           &copy; {new Date().getFullYear()} QuickConv
         </p>

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -18,10 +18,67 @@
     "convertAnother": "Convert Another",
     "expiresIn": "File expires in {hours} hours",
     "language": "Language",
-    "privacy": "Files are automatically deleted after 24 hours"
+    "privacy": "Files are automatically deleted after 24 hours",
+    "privacyPolicy": "Privacy Policy",
+    "termsOfService": "Terms of Service"
   },
   "seo": {
     "titleTemplate": "{from} to {to} Converter - Free Online | QuickConv",
     "descriptionTemplate": "Convert {from} to {to} online for free. No registration, no watermark. Fast and secure image conversion."
+  },
+  "cookieConsent": {
+    "message": "This website uses cookies to provide you with a better experience. We use cookies for rate limiting and service improvement.",
+    "accept": "Accept",
+    "reject": "Reject",
+    "learnMore": "Learn more in our {privacyPolicy}."
+  },
+  "privacyPolicy": {
+    "title": "Privacy Policy",
+    "lastUpdated": "Last updated: March 15, 2026",
+    "intro": "QuickConv (\"we\", \"us\", \"our\") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and safeguard your information when you use our service.",
+    "dataCollectionTitle": "Data We Collect",
+    "dataCollectionDescription": "We collect the following data to operate our service:",
+    "dataIpHash": "IP address hash (anonymized, not your actual IP address)",
+    "dataCookieId": "Cookie ID (for session management)",
+    "dataUserAgent": "User-Agent (browser and device information)",
+    "purposeTitle": "Purpose of Data Collection",
+    "purposeDescription": "We use the collected data solely for the following purposes:",
+    "purposeRateLimit": "Rate limiting to ensure fair usage of the service",
+    "purposeServiceImprovement": "Service improvement and abuse prevention",
+    "retentionTitle": "Data Retention",
+    "retentionDescription": "All collected data is automatically deleted after 30 days. Uploaded files are automatically deleted within 24 hours of conversion.",
+    "thirdPartyTitle": "Third-Party Sharing",
+    "thirdPartyDescription": "We do not share, sell, or transfer your personal data to any third parties.",
+    "cookiesTitle": "Cookies",
+    "cookiesDescription": "We use essential cookies for rate limiting and session management. If you reject cookies through our cookie consent banner, no cookies will be issued by our service.",
+    "rightsTitle": "Your Rights",
+    "rightsDescription": "You have the right to:",
+    "rightsAccess": "Request access to your data",
+    "rightsDelete": "Request deletion of your data",
+    "rightsRestrict": "Restrict processing of your data",
+    "rightsContact": "To exercise these rights, please contact us at privacy@quickconv.io.",
+    "changesTitle": "Changes to This Policy",
+    "changesDescription": "We may update this Privacy Policy from time to time. Any changes will be posted on this page with an updated revision date."
+  },
+  "termsOfService": {
+    "title": "Terms of Service",
+    "lastUpdated": "Last updated: March 15, 2026",
+    "intro": "By using QuickConv (\"the Service\"), you agree to these Terms of Service. Please read them carefully.",
+    "serviceTitle": "Service Description",
+    "serviceDescription": "QuickConv provides free online file conversion services. We convert files between various formats including images (HEIC, WebP, AVIF, PNG, JPG, GIF, SVG).",
+    "usageTitle": "Acceptable Use",
+    "usageDescription": "By using our Service, you agree to:",
+    "usageLegal": "Only upload files you have the legal right to convert",
+    "usageNoMalicious": "Not upload malicious files (viruses, malware, etc.)",
+    "usageNoAbuse": "Not abuse or attempt to disrupt the Service",
+    "usageComply": "Comply with all applicable laws and regulations",
+    "filesTitle": "File Handling",
+    "filesDescription": "Uploaded files are processed on our servers and automatically deleted within 24 hours. We do not store, review, or share your files beyond what is necessary for conversion.",
+    "disclaimerTitle": "Disclaimer of Warranties",
+    "disclaimerDescription": "The Service is provided \"as is\" without any warranties, express or implied. We do not guarantee that the Service will be uninterrupted, error-free, or that converted files will meet your specific requirements.",
+    "limitationTitle": "Limitation of Liability",
+    "limitationDescription": "To the fullest extent permitted by law, QuickConv shall not be liable for any indirect, incidental, special, or consequential damages arising from your use of the Service.",
+    "changesTitle": "Changes to Terms",
+    "changesDescription": "We reserve the right to modify these Terms at any time. Continued use of the Service after changes constitutes acceptance of the updated Terms."
   }
 }

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -18,10 +18,67 @@
     "convertAnother": "別のファイルを変換",
     "expiresIn": "ファイルは{hours}時間後に自動削除されます",
     "language": "言語",
-    "privacy": "ファイルは24時間後に自動削除されます"
+    "privacy": "ファイルは24時間後に自動削除されます",
+    "privacyPolicy": "プライバシーポリシー",
+    "termsOfService": "利用規約"
   },
   "seo": {
     "titleTemplate": "{from}から{to}への変換 - 無料オンライン | QuickConv",
     "descriptionTemplate": "{from}を{to}にオンラインで無料変換。登録不要、ウォーターマークなし。高速で安全な画像変換。"
+  },
+  "cookieConsent": {
+    "message": "当サイトでは、より良いサービスを提供するためにCookieを使用しています。レート制限およびサービス改善の目的で使用されます。",
+    "accept": "同意する",
+    "reject": "拒否する",
+    "learnMore": "詳細は{privacyPolicy}をご覧ください。"
+  },
+  "privacyPolicy": {
+    "title": "プライバシーポリシー",
+    "lastUpdated": "最終更新日: 2026年3月15日",
+    "intro": "QuickConv（以下「当サービス」）は、お客様のプライバシーの保護に努めています。本プライバシーポリシーは、当サービスの利用に際して収集、使用、保護する情報について説明します。",
+    "dataCollectionTitle": "収集するデータ",
+    "dataCollectionDescription": "当サービスの運営のため、以下のデータを収集します:",
+    "dataIpHash": "IPアドレスのハッシュ（匿名化されており、実際のIPアドレスではありません）",
+    "dataCookieId": "Cookie ID（セッション管理のため）",
+    "dataUserAgent": "User-Agent（ブラウザおよびデバイス情報）",
+    "purposeTitle": "データ収集の目的",
+    "purposeDescription": "収集したデータは、以下の目的でのみ使用します:",
+    "purposeRateLimit": "サービスの公平な利用を確保するためのレート制限",
+    "purposeServiceImprovement": "サービスの改善および不正利用の防止",
+    "retentionTitle": "データの保持期間",
+    "retentionDescription": "収集したすべてのデータは、30日後に自動的に削除されます。アップロードされたファイルは、変換後24時間以内に自動削除されます。",
+    "thirdPartyTitle": "第三者への提供",
+    "thirdPartyDescription": "お客様の個人データを第三者と共有、販売、または移転することはありません。",
+    "cookiesTitle": "Cookie について",
+    "cookiesDescription": "当サービスでは、レート制限およびセッション管理のために必要最小限のCookieを使用します。Cookie同意バナーでCookieを拒否した場合、当サービスからCookieは発行されません。",
+    "rightsTitle": "お客様の権利",
+    "rightsDescription": "お客様には以下の権利があります:",
+    "rightsAccess": "データへのアクセスの要求",
+    "rightsDelete": "データの削除の要求",
+    "rightsRestrict": "データ処理の制限の要求",
+    "rightsContact": "これらの権利を行使するには、privacy@quickconv.io までご連絡ください。",
+    "changesTitle": "ポリシーの変更",
+    "changesDescription": "本プライバシーポリシーは随時更新される場合があります。変更がある場合は、改訂日を更新のうえ本ページに掲載します。"
+  },
+  "termsOfService": {
+    "title": "利用規約",
+    "lastUpdated": "最終更新日: 2026年3月15日",
+    "intro": "QuickConv（以下「本サービス」）をご利用いただくにあたり、以下の利用規約に同意いただくものとします。",
+    "serviceTitle": "サービスの概要",
+    "serviceDescription": "QuickConvは、無料のオンラインファイル変換サービスを提供します。画像（HEIC、WebP、AVIF、PNG、JPG、GIF、SVG）を含む様々なフォーマット間でファイルを変換できます。",
+    "usageTitle": "利用にあたっての注意事項",
+    "usageDescription": "本サービスの利用にあたり、以下の事項に同意いただくものとします:",
+    "usageLegal": "変換する法的権利を有するファイルのみアップロードすること",
+    "usageNoMalicious": "悪意のあるファイル（ウイルス、マルウェア等）をアップロードしないこと",
+    "usageNoAbuse": "本サービスの不正利用や妨害を試みないこと",
+    "usageComply": "適用されるすべての法令を遵守すること",
+    "filesTitle": "ファイルの取り扱い",
+    "filesDescription": "アップロードされたファイルはサーバー上で処理され、24時間以内に自動削除されます。変換に必要な範囲を超えてファイルを保存、閲覧、共有することはありません。",
+    "disclaimerTitle": "免責事項",
+    "disclaimerDescription": "本サービスは「現状のまま」提供され、明示または黙示を問わずいかなる保証も行いません。サービスの中断がないこと、エラーがないこと、変換されたファイルがお客様の特定の要件を満たすことを保証するものではありません。",
+    "limitationTitle": "責任の制限",
+    "limitationDescription": "法律で認められる最大限の範囲において、QuickConvは本サービスの利用に起因する間接的、偶発的、特別、または結果的な損害について責任を負いません。",
+    "changesTitle": "規約の変更",
+    "changesDescription": "当社は、いつでも本規約を変更する権利を有します。変更後も本サービスを継続してご利用いただいた場合、更新された規約に同意したものとみなされます。"
   }
 }


### PR DESCRIPTION
## Summary
- Cookie同意バナー（GDPR対応）を追加。LocalStorage (`qc_cookie_consent`) で同意/拒否状態を永続化
- プライバシーポリシーページ (`/[locale]/privacy`) を日英で追加
- 利用規約ページ (`/[locale]/terms`) を日英で追加
- フッターにPrivacy Policy / Terms of Serviceリンクを追加

## Changes
- `apps/web/src/components/cookie-consent.tsx` - Cookie同意バナー（"use client"）
- `apps/web/src/app/[locale]/privacy/page.tsx` - プライバシーポリシーページ
- `apps/web/src/app/[locale]/terms/page.tsx` - 利用規約ページ
- `apps/web/src/components/footer.tsx` - Privacy/Termsリンク追加
- `apps/web/src/app/[locale]/layout.tsx` - CookieConsentコンポーネント追加
- `apps/web/src/messages/en.json` / `ja.json` - i18nメッセージ追加

## Test plan
- [ ] 初回訪問時にCookie同意バナーが表示される
- [ ] 「Accept」クリック後、LocalStorageに`qc_cookie_consent=accepted`が保存される
- [ ] 「Reject」クリック後、LocalStorageに`qc_cookie_consent=rejected`が保存される
- [ ] 同意/拒否後にバナーが再表示されない
- [ ] `/en/privacy` と `/ja/privacy` が正しく表示される
- [ ] `/en/terms` と `/ja/terms` が正しく表示される
- [ ] フッターのPrivacy/Termsリンクが正しく動作する
- [ ] 言語切替でPrivacy/Termsページも正しく切り替わる
- [ ] `npx turbo build --filter=@quickconv/web` でビルド成功

Closes #17