### PR TITLE
feat(seo): add robots.txt and sitemap.xml generation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3000",
-    "build": "next build",
+    "build": "next build && tsx scripts/generate-sitemap.ts",
     "start": "next start",
     "lint": "next lint"
   },
@@ -26,6 +26,7 @@
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",
     "@tailwindcss/postcss": "^4.0.0",
-    "postcss": "^8.4.0"
+    "postcss": "^8.4.0",
+    "tsx": "^4.21.0"
   }
 }

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+
+Sitemap: https://quickconv.cc/sitemap.xml

--- a/apps/web/scripts/generate-sitemap.ts
+++ b/apps/web/scripts/generate-sitemap.ts
@@ -1,0 +1,66 @@
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+import { CONVERSION_PAIRS } from "@quickconv/shared";
+
+const BASE_URL = "https://quickconv.cc";
+const LOCALES = ["en", "ja"] as const;
+const OUTPUT_PATH = resolve(__dirname, "../out/sitemap.xml");
+
+interface SitemapEntry {
+  path: string;
+}
+
+function getStaticPages(): SitemapEntry[] {
+  return [{ path: "" }, { path: "/privacy" }, { path: "/terms" }];
+}
+
+function getConversionPages(): SitemapEntry[] {
+  const pages: SitemapEntry[] = [];
+  for (const [from, targets] of Object.entries(CONVERSION_PAIRS)) {
+    for (const to of targets) {
+      pages.push({ path: `/convert/${from}-to-${to}` });
+    }
+  }
+  return pages;
+}
+
+function buildHreflangLinks(path: string): string {
+  return LOCALES.map(
+    (locale) =>
+      `      <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}/${locale}${path}" />`
+  ).join("\n");
+}
+
+function buildUrlEntry(locale: string, path: string): string {
+  return `  <url>
+    <loc>${BASE_URL}/${locale}${path}</loc>
+${buildHreflangLinks(path)}
+    <changefreq>weekly</changefreq>
+  </url>`;
+}
+
+function generateSitemap(): string {
+  const pages = [...getStaticPages(), ...getConversionPages()];
+
+  const urls = pages.flatMap((page) =>
+    LOCALES.map((locale) => buildUrlEntry(locale, page.path))
+  );
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+>
+${urls.join("\n")}
+</urlset>
+`;
+}
+
+function main(): void {
+  const sitemap = generateSitemap();
+  writeFileSync(OUTPUT_PATH, sitemap, "utf-8");
+  const urlCount = (sitemap.match(/<url>/g) || []).length;
+  console.log(`Sitemap generated: ${OUTPUT_PATH} (${urlCount} URLs)`);
+}
+
+main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Add `robots.txt` with API path disallow and sitemap reference to `https://quickconv.cc/sitemap.xml`
- Add `generate-sitemap.ts` build-time script that dynamically generates `sitemap.xml` from `CONVERSION_PAIRS`
- All public pages (top, privacy, terms, conversion pages) included with `hreflang` alternates for en/ja

## Details
- Static export (`output: "export"`) prevents use of Next.js `generateSitemaps` API, so a post-build script approach is used
- Script imports `CONVERSION_PAIRS` from `@quickconv/shared` to ensure sitemap stays in sync with supported conversions
- 52 URLs generated: 2 locales x (3 static pages + 23 conversion pairs)
- `tsx` added as devDependency for TypeScript script execution

## Test plan
- [x] `npx turbo build --filter=@quickconv/web` succeeds
- [x] `robots.txt` present in build output with correct format
- [x] `sitemap.xml` generated with 52 URLs
- [x] All conversion pairs from `CONVERSION_PAIRS` included
- [x] `hreflang` alternates present for both en and ja
- [x] XML Sitemap spec compliant (`xmlns`, `xhtml:link`)

Closes #41