### PR TITLE
feat: GA4カスタムイベント計測 (#48)

### DIFF
--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -7,13 +7,15 @@ import { FileDropzone } from "./file-dropzone";
 import { FormatSelector } from "./format-selector";
 import { ProgressBar } from "./progress-bar";
 import { useConversion } from "@/hooks/use-conversion";
+import { useGAEvent } from "@/hooks/use-ga-event";
 import type { ImageFormat } from "@quickconv/shared";
 
 export function ConversionCard() {
   const t = useTranslations("common");
   const [file, setFile] = useState<File | null>(null);
   const [outputFormat, setOutputFormat] = useState<ImageFormat | null>(null);
-  const { step, uploadProgress, downloadUrl, error, startConversion, reset } = useConversion();
+  const { step, uploadProgress, downloadUrl, error, startConversion, reset, inputFormat, outputFormat: convOutputFormat } = useConversion();
+  const { trackFileDownload } = useGAEvent();
 
   const handleFileSelect = (selectedFile: File) => {
     setFile(selectedFile);
@@ -96,6 +98,7 @@ export function ConversionCard() {
           <a
             href={downloadUrl}
             download
+            onClick={() => trackFileDownload(inputFormat, convOutputFormat)}
             className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
           >
             <Download className="h-4 w-4" />

--- a/apps/web/src/hooks/use-conversion.ts
+++ b/apps/web/src/hooks/use-conversion.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef } from "react";
 import { uploadFile, requestConversion, checkStatus, getDownloadUrl } from "@/lib/api-client";
 import { POLLING_INTERVAL_MS } from "@quickconv/shared";
 import type { ImageFormat } from "@quickconv/shared";
+import { useGAEvent } from "./use-ga-event";
 
 type Step = "idle" | "uploading" | "converting" | "completed" | "failed";
 
@@ -24,6 +25,9 @@ export function useConversion() {
     error: null,
   });
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startTimeRef = useRef<number>(0);
+  const formatsRef = useRef<{ from: string; to: string }>({ from: "", to: "" });
+  const { trackFileUpload, trackConversionStart, trackConversionComplete, trackConversionError } = useGAEvent();
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -36,14 +40,22 @@ export function useConversion() {
     async (file: File, outputFormat: ImageFormat) => {
       setState({ step: "uploading", uploadProgress: 0, jobId: null, downloadUrl: null, error: null });
 
+      const inputFormat = file.name.split(".").pop()?.toLowerCase() || "unknown";
+      formatsRef.current = { from: inputFormat, to: outputFormat };
+
       try {
         // Step 1: Upload
         const uploaded = await uploadFile(file, (progress) => {
           setState((s) => ({ ...s, uploadProgress: progress }));
         });
 
+        trackFileUpload(inputFormat, Math.round(file.size / 1024), 1);
+
         // Step 2: Request conversion
         setState((s) => ({ ...s, step: "converting", uploadProgress: 100 }));
+        startTimeRef.current = Date.now();
+        trackConversionStart(inputFormat, outputFormat);
+
         const { jobId } = await requestConversion(uploaded.fileId, outputFormat);
         setState((s) => ({ ...s, jobId }));
 
@@ -54,6 +66,8 @@ export function useConversion() {
 
             if (status.status === "completed") {
               stopPolling();
+              const durationMs = Date.now() - startTimeRef.current;
+              trackConversionComplete(inputFormat, outputFormat, durationMs);
               setState((s) => ({
                 ...s,
                 step: "completed",
@@ -61,6 +75,8 @@ export function useConversion() {
               }));
             } else if (status.status === "failed") {
               stopPolling();
+              const errorType = status.error || "unknown";
+              trackConversionError(inputFormat, outputFormat, errorType);
               setState((s) => ({
                 ...s,
                 step: "failed",
@@ -69,11 +85,14 @@ export function useConversion() {
             }
           } catch {
             stopPolling();
+            trackConversionError(inputFormat, outputFormat, "connection_lost");
             setState((s) => ({ ...s, step: "failed", error: "Lost connection" }));
           }
         }, POLLING_INTERVAL_MS);
       } catch (error) {
         stopPolling();
+        const errorType = (error as Error).message || "unknown";
+        trackConversionError(inputFormat, outputFormat, errorType);
         setState((s) => ({
           ...s,
           step: "failed",
@@ -81,7 +100,7 @@ export function useConversion() {
         }));
       }
     },
-    [stopPolling]
+    [stopPolling, trackFileUpload, trackConversionStart, trackConversionComplete, trackConversionError]
   );
 
   const reset = useCallback(() => {
@@ -89,5 +108,5 @@ export function useConversion() {
     setState({ step: "idle", uploadProgress: 0, jobId: null, downloadUrl: null, error: null });
   }, [stopPolling]);
 
-  return { ...state, startConversion, reset };
+  return { ...state, startConversion, reset, inputFormat: formatsRef.current.from, outputFormat: formatsRef.current.to };
 }

--- a/apps/web/src/hooks/use-ga-event.ts
+++ b/apps/web/src/hooks/use-ga-event.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback } from "react";
+
+type GAEventParams = Record<string, string | number | boolean>;
+
+function hasConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return localStorage.getItem("qc_cookie_consent") === "accepted";
+  } catch {
+    return false;
+  }
+}
+
+function sendEvent(eventName: string, params?: GAEventParams): void {
+  if (typeof window === "undefined") return;
+  if (typeof window.gtag !== "function") return;
+  if (!hasConsent()) return;
+
+  window.gtag("event", eventName, params);
+}
+
+export function useGAEvent() {
+  const trackFileUpload = useCallback(
+    (fileType: string, sizeKb: number, count: number) => {
+      sendEvent("file_upload", {
+        format: fileType,
+        size_kb: sizeKb,
+        count,
+      });
+    },
+    []
+  );
+
+  const trackConversionStart = useCallback(
+    (from: string, to: string) => {
+      sendEvent("conversion_start", { from, to });
+    },
+    []
+  );
+
+  const trackConversionComplete = useCallback(
+    (from: string, to: string, durationMs: number) => {
+      sendEvent("conversion_complete", { from, to, duration_ms: durationMs });
+    },
+    []
+  );
+
+  const trackConversionError = useCallback(
+    (from: string, to: string, errorType: string) => {
+      sendEvent("conversion_error", { from, to, error_type: errorType });
+    },
+    []
+  );
+
+  const trackFileDownload = useCallback(
+    (from: string, to: string) => {
+      sendEvent("file_download", { from, to });
+    },
+    []
+  );
+
+  return {
+    trackFileUpload,
+    trackConversionStart,
+    trackConversionComplete,
+    trackConversionError,
+    trackFileDownload,
+  };
+}


### PR DESCRIPTION
## Summary
- `useGAEvent` フックを新規作成 -- Cookie同意チェック + `window.gtag` 存在確認の安全処理付きイベント送信ヘルパー
- `useConversion` フックに5種類のGA4イベント送信を組み込み (file_upload, conversion_start, conversion_complete, conversion_error)
- `ConversionCard` のDLボタンに file_download イベントを追加

## Events
| Event | Params | Trigger |
|---|---|---|
| file_upload | format, size_kb, count | Upload complete |
| conversion_start | from, to | API request fired |
| conversion_complete | from, to, duration_ms | Download URL received |
| conversion_error | from, to, error_type | Error occurred |
| file_download | from, to | Download button click |

## Test plan
- [ ] ブラウザDevTools > Network でgtagリクエストを確認
- [ ] Cookie同意なし状態でイベントが送信されないことを確認
- [ ] 変換成功時に file_upload, conversion_start, conversion_complete が順次送信されること
- [ ] 変換失敗時に conversion_error が送信されること
- [ ] DLボタンクリックで file_download が送信されること
- [ ] TypeScript型チェック通過

Closes #48