### PR TITLE
feat(api): add rate-limit middleware (#16)

### DIFF
--- a/apps/api/src/__tests__/rate-limit-middleware.test.ts
+++ b/apps/api/src/__tests__/rate-limit-middleware.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { Hono } from "hono";
+import type { Env, AppVariables } from "../types/env";
+import type { RateLimitCheckFn } from "../middleware/rate-limit";
+import {
+  rateLimitMiddleware,
+  fileSizeLimitMiddleware,
+  uploadRateLimitMiddleware,
+} from "../middleware/rate-limit";
+
+/** vi.fn() を RateLimitCheckFn として型安全に使うためのヘルパー */
+function createMockFn() {
+  return vi.fn() as unknown as RateLimitCheckFn & Mock;
+}
+
+const FAKE_DB = {} as D1Database;
+const FAKE_ENV = {
+  DB: FAKE_DB,
+  R2_BUCKET: {},
+  CORS_ORIGIN: "*",
+  CONVERTER_URL: "",
+  CONVERTER_API_KEY: "",
+} as unknown as Env;
+
+function createApp() {
+  return new Hono<{ Bindings: Env; Variables: AppVariables }>();
+}
+
+/** Hono app.request のヘルパー: request(input, requestInit?, Env?, execCtx?) */
+async function appRequest(
+  app: Hono<{ Bindings: Env; Variables: AppVariables }>,
+  path: string,
+  options?: RequestInit,
+) {
+  return app.request(path, options, FAKE_ENV);
+}
+
+describe("rateLimitMiddleware", () => {
+  let mockConsume: RateLimitCheckFn & Mock;
+
+  beforeEach(() => {
+    mockConsume = createMockFn();
+  });
+
+  it("returns 401 when clientHash is missing", async () => {
+    const app = createApp();
+    app.use("/convert/*", rateLimitMiddleware(mockConsume));
+    app.post("/convert", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/convert", { method: "POST" });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("identification_required");
+    expect(mockConsume).not.toHaveBeenCalled();
+  });
+
+  it("allows request when under limit (count=3)", async () => {
+    mockConsume.mockResolvedValue({
+      allowed: true,
+      remaining: 6,
+      limit: 10,
+      resetDate: "2026-03-15",
+    });
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "test-hash");
+      await next();
+    });
+    app.use("/convert/*", rateLimitMiddleware(mockConsume));
+    app.post("/convert", (c) =>
+      c.json({ ok: true, remaining: c.get("rateLimitRemaining") }),
+    );
+
+    const res = await appRequest(app, "/convert", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.remaining).toBe(6);
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("6");
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+  });
+
+  it("allows 10th conversion (count=9 -> remaining=0)", async () => {
+    mockConsume.mockResolvedValue({
+      allowed: true,
+      remaining: 0,
+      limit: 10,
+      resetDate: "2026-03-15",
+    });
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "test-hash");
+      await next();
+    });
+    app.use("/convert/*", rateLimitMiddleware(mockConsume));
+    app.post("/convert", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/convert", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+  });
+
+  it("blocks 11th conversion with 429 (count=10)", async () => {
+    mockConsume.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      limit: 10,
+      resetDate: "2026-03-15",
+    });
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "test-hash");
+      await next();
+    });
+    app.use("/convert/*", rateLimitMiddleware(mockConsume));
+    app.post("/convert", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/convert", { method: "POST" });
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("rate_limit");
+    expect(body.remaining).toBe(0);
+    expect(body.resetAt).toBe("2026-03-16T00:00:00.000Z");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(res.headers.get("Retry-After")).toBe("2026-03-16T00:00:00.000Z");
+  });
+
+  it("includes resetAt as next UTC midnight (year boundary)", async () => {
+    mockConsume.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      limit: 10,
+      resetDate: "2026-12-31",
+    });
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "test-hash");
+      await next();
+    });
+    app.use("/convert/*", rateLimitMiddleware(mockConsume));
+    app.post("/convert", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/convert", { method: "POST" });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.resetAt).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  it("passes DB and clientHash to consumeRateLimit", async () => {
+    mockConsume.mockResolvedValue({
+      allowed: true,
+      remaining: 9,
+      limit: 10,
+      resetDate: "2026-03-15",
+    });
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "abc-123");
+      await next();
+    });
+    app.use("/convert/*", rateLimitMiddleware(mockConsume));
+    app.post("/convert", (c) => c.json({ ok: true }));
+
+    await appRequest(app, "/convert", { method: "POST" });
+    expect(mockConsume).toHaveBeenCalledWith(FAKE_DB, "abc-123");
+  });
+});
+
+describe("fileSizeLimitMiddleware", () => {
+  it("blocks request when Content-Length exceeds 10MB with 413", async () => {
+    const app = createApp();
+    app.use("/upload/*", fileSizeLimitMiddleware());
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    const oversizeLength = String(11 * 1024 * 1024);
+    const res = await app.request("/upload", {
+      method: "POST",
+      headers: { "Content-Length": oversizeLength },
+    }, FAKE_ENV);
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("file_too_large");
+    expect(body.maxSizeBytes).toBe(10 * 1024 * 1024);
+  });
+
+  it("allows request when Content-Length is under 10MB", async () => {
+    const app = createApp();
+    app.use("/upload/*", fileSizeLimitMiddleware());
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    const normalLength = String(5 * 1024 * 1024);
+    const res = await app.request("/upload", {
+      method: "POST",
+      headers: { "Content-Length": normalLength },
+    }, FAKE_ENV);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows request when Content-Length is exactly 10MB", async () => {
+    const app = createApp();
+    app.use("/upload/*", fileSizeLimitMiddleware());
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    const exactLength = String(10 * 1024 * 1024);
+    const res = await app.request("/upload", {
+      method: "POST",
+      headers: { "Content-Length": exactLength },
+    }, FAKE_ENV);
+    expect(res.status).toBe(200);
+  });
+
+  it("passes through when Content-Length header is absent", async () => {
+    const app = createApp();
+    app.use("/upload/*", fileSizeLimitMiddleware());
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/upload", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("uploadRateLimitMiddleware", () => {
+  let mockCheck: RateLimitCheckFn & Mock;
+
+  beforeEach(() => {
+    mockCheck = createMockFn();
+  });
+
+  it("returns 401 when clientHash is missing", async () => {
+    const app = createApp();
+    app.use("/upload/*", uploadRateLimitMiddleware(mockCheck));
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/upload", { method: "POST" });
+    expect(res.status).toBe(401);
+    expect(mockCheck).not.toHaveBeenCalled();
+  });
+
+  it("allows upload when under rate limit", async () => {
+    mockCheck.mockResolvedValue({
+      allowed: true,
+      remaining: 5,
+      limit: 10,
+      resetDate: "2026-03-15",
+    });
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "test-hash");
+      await next();
+    });
+    app.use("/upload/*", uploadRateLimitMiddleware(mockCheck));
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/upload", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("5");
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+  });
+
+  it("blocks upload with 429 when rate limit exceeded", async () => {
+    mockCheck.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      limit: 10,
+      resetDate: "2026-03-15",
+    });
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "test-hash");
+      await next();
+    });
+    app.use("/upload/*", uploadRateLimitMiddleware(mockCheck));
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    const res = await appRequest(app, "/upload", { method: "POST" });
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("rate_limit");
+    expect(body.remaining).toBe(0);
+  });
+
+  it("uses checkRateLimit (read-only, no increment)", async () => {
+    mockCheck.mockResolvedValue({
+      allowed: true,
+      remaining: 8,
+      limit: 10,
+      resetDate: "2026-03-15",
+    });
+
+    const mockConsume = createMockFn();
+
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.set("clientHash", "test-hash");
+      await next();
+    });
+    app.use("/upload/*", uploadRateLimitMiddleware(mockCheck));
+    app.post("/upload", (c) => c.json({ ok: true }));
+
+    await appRequest(app, "/upload", { method: "POST" });
+    expect(mockCheck).toHaveBeenCalledOnce();
+    expect(mockConsume).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,11 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { Env, AppVariables } from "./types/env";
 import { identificationMiddleware } from "./middleware/identification";
+import {
+  rateLimitMiddleware,
+  fileSizeLimitMiddleware,
+  uploadRateLimitMiddleware,
+} from "./middleware/rate-limit";
 import upload from "./routes/upload";
 import convert from "./routes/convert";
 import status from "./routes/status";
@@ -32,6 +37,11 @@ app.use(
 
 // Identification — CORS の後、ルートの前に適用
 app.use("/api/*", identificationMiddleware());
+
+// Rate limiting — upload にはサイズ制限 + 読み取り専用チェック、convert にはカウント消費
+app.use("/api/upload", fileSizeLimitMiddleware());
+app.use("/api/upload", uploadRateLimitMiddleware());
+app.use("/api/convert", rateLimitMiddleware());
 
 // Health check
 app.get("/health", (c) => c.json({ status: "ok" }));

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,134 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env, AppVariables } from "../types/env";
+import type { RateLimitResult } from "@quickconv/shared";
+import { ANONYMOUS_MAX_FILE_SIZE_BYTES } from "../domain/rate-limit-policy";
+import {
+  checkRateLimit as defaultCheckRateLimit,
+  consumeRateLimit as defaultConsumeRateLimit,
+} from "../services/rate-limit";
+
+type HonoEnv = { Bindings: Env; Variables: AppVariables };
+
+/** レート制限ユースケース関数の型 */
+export type RateLimitCheckFn = (db: D1Database, clientHash: string) => Promise<RateLimitResult>;
+
+/** 429 レスポンス共通ヘルパー */
+function buildResetAt(resetDate: string): string {
+  const tomorrow = new Date(resetDate);
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  return tomorrow.toISOString();
+}
+
+/**
+ * ファイルサイズ制限ミドルウェア（/api/upload 用）
+ *
+ * 匿名ユーザーの1ファイル上限（10MB）を超える場合は 413 を返す。
+ * Content-Length ヘッダーで事前チェックし、無駄なボディ読み込みを回避する。
+ */
+export const fileSizeLimitMiddleware = (): MiddlewareHandler<HonoEnv> => {
+  return async (c, next) => {
+    const contentLength = c.req.header("content-length");
+    if (contentLength) {
+      const size = Number.parseInt(contentLength, 10);
+      if (!Number.isNaN(size) && size > ANONYMOUS_MAX_FILE_SIZE_BYTES) {
+        return c.json(
+          {
+            error: "file_too_large",
+            message: `File size exceeds ${ANONYMOUS_MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB limit`,
+            maxSizeBytes: ANONYMOUS_MAX_FILE_SIZE_BYTES,
+          },
+          413,
+        );
+      }
+    }
+    await next();
+  };
+};
+
+/**
+ * レート制限ミドルウェア（/api/convert 用）
+ *
+ * - identificationMiddleware でセット済みの clientHash を取得
+ * - 日次カウントが上限（10回）を超えていれば 429 を返す
+ * - 超えていなければカウントをインクリメントして通過
+ * - レスポンスヘッダーに X-RateLimit-Remaining, X-RateLimit-Limit を付与
+ */
+export const rateLimitMiddleware = (
+  consumeFn: RateLimitCheckFn = defaultConsumeRateLimit,
+): MiddlewareHandler<HonoEnv> => {
+  return async (c, next) => {
+    const clientHash = c.get("clientHash");
+    if (!clientHash) {
+      return c.json({ error: "identification_required" }, 401);
+    }
+
+    const result = await consumeFn(c.env.DB, clientHash);
+
+    if (!result.allowed) {
+      const resetAt = buildResetAt(result.resetDate);
+
+      c.header("X-RateLimit-Remaining", "0");
+      c.header("X-RateLimit-Limit", String(result.limit));
+      c.header("Retry-After", resetAt);
+
+      return c.json(
+        {
+          error: "rate_limit",
+          remaining: 0,
+          resetAt,
+        },
+        429,
+      );
+    }
+
+    // レート制限情報をコンテキストに保存（ルートハンドラで利用可能に）
+    c.set("rateLimitRemaining", result.remaining);
+    c.set("rateLimitLimit", result.limit);
+
+    await next();
+
+    // レスポンスヘッダーに付与
+    c.header("X-RateLimit-Remaining", String(result.remaining));
+    c.header("X-RateLimit-Limit", String(result.limit));
+  };
+};
+
+/**
+ * アップロード用レート制限チェックミドルウェア（/api/upload 用）
+ *
+ * カウンターはインクリメントしない（読み取り専用）。
+ * アップロード時点で上限到達済みならブロックし、無駄なR2書き込みを回避する。
+ */
+export const uploadRateLimitMiddleware = (
+  checkFn: RateLimitCheckFn = defaultCheckRateLimit,
+): MiddlewareHandler<HonoEnv> => {
+  return async (c, next) => {
+    const clientHash = c.get("clientHash");
+    if (!clientHash) {
+      return c.json({ error: "identification_required" }, 401);
+    }
+
+    const result = await checkFn(c.env.DB, clientHash);
+
+    if (!result.allowed) {
+      const resetAt = buildResetAt(result.resetDate);
+
+      c.header("X-RateLimit-Remaining", "0");
+      c.header("X-RateLimit-Limit", String(result.limit));
+
+      return c.json(
+        {
+          error: "rate_limit",
+          remaining: 0,
+          resetAt,
+        },
+        429,
+      );
+    }
+
+    await next();
+
+    c.header("X-RateLimit-Remaining", String(result.remaining));
+    c.header("X-RateLimit-Limit", String(result.limit));
+  };
+};

--- a/apps/api/src/routes/convert.ts
+++ b/apps/api/src/routes/convert.ts
@@ -1,12 +1,12 @@
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
 import { convertSchema, CONVERSION_PAIRS, FILE_EXPIRY_HOURS, FORMAT_TO_MIME } from "@quickconv/shared";
-import type { Env } from "../types/env";
+import type { Env, AppVariables } from "../types/env";
 import { createJob, updateJobStatus } from "../services/d1";
 import { requestDirectConversion } from "../services/converter";
 import { uploadToR2 } from "../services/r2";
 
-const convert = new Hono<{ Bindings: Env }>();
+const convert = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 convert.post("/", async (c) => {
   const body = await c.req.json();
@@ -77,7 +77,12 @@ convert.post("/", async (c) => {
     fileSize: result.fileSize,
   });
 
-  return c.json({ jobId, status: "completed" });
+  return c.json({
+    jobId,
+    status: "completed",
+    remainingConversions: c.get("rateLimitRemaining"),
+    dailyLimit: c.get("rateLimitLimit"),
+  });
 });
 
 export default convert;

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -1,10 +1,15 @@
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
-import { MIME_TO_FORMAT, ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES } from "@quickconv/shared";
-import type { Env } from "../types/env";
+import {
+  MIME_TO_FORMAT,
+  ALLOWED_MIME_TYPES,
+  MAX_FILE_SIZE_BYTES,
+  ANONYMOUS_MAX_FILE_SIZE_BYTES,
+} from "@quickconv/shared";
+import type { Env, AppVariables } from "../types/env";
 import { uploadToR2 } from "../services/r2";
 
-const upload = new Hono<{ Bindings: Env }>();
+const upload = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 upload.post("/", async (c) => {
   const body = await c.req.parseBody();
@@ -12,6 +17,18 @@ upload.post("/", async (c) => {
 
   if (!file || !(file instanceof File)) {
     return c.json({ error: "validation", message: "No file provided" }, 400);
+  }
+
+  // 匿名ユーザーの10MB制限（ボディパース後の実サイズチェック）
+  if (file.size > ANONYMOUS_MAX_FILE_SIZE_BYTES) {
+    return c.json(
+      {
+        error: "file_too_large",
+        message: `File size exceeds ${ANONYMOUS_MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB limit`,
+        maxSizeBytes: ANONYMOUS_MAX_FILE_SIZE_BYTES,
+      },
+      413,
+    );
   }
 
   if (file.size > MAX_FILE_SIZE_BYTES) {

--- a/apps/api/src/types/env.ts
+++ b/apps/api/src/types/env.ts
@@ -8,4 +8,6 @@ export interface Env {
 
 export interface AppVariables {
   clientHash: string;
+  rateLimitRemaining: number;
+  rateLimitLimit: number;
 }


### PR DESCRIPTION
## Summary
- `/api/convert` にレート制限ミドルウェア適用（日次10回制限、11回目から429）
- `/api/upload` にファイルサイズ制限（10MB超で413）+ 読み取り専用レート制限チェック
- レスポンスヘッダー（X-RateLimit-Remaining, X-RateLimit-Limit）と残り回数レスポンスボディ

## Changes
| File | What |
|---|---|
| `apps/api/src/middleware/rate-limit.ts` | 3つのミドルウェア（rateLimitMiddleware, fileSizeLimitMiddleware, uploadRateLimitMiddleware） |
| `apps/api/src/index.ts` | ミドルウェアの適用 |
| `apps/api/src/routes/upload.ts` | 10MB制限チェック追加 |
| `apps/api/src/routes/convert.ts` | レスポンスに remainingConversions, dailyLimit 追加 |
| `apps/api/src/types/env.ts` | AppVariables に rateLimitRemaining, rateLimitLimit 追加 |
| `apps/api/src/__tests__/rate-limit-middleware.test.ts` | 14テスト追加 |

## Test plan
- [x] 11回目の変換リクエストが429で拒否される
- [x] 10MB超のファイルが413で拒否される
- [x] レスポンスに残り回数が含まれる
- [x] 10回目の変換は正常に実行される
- [x] 全35テスト合格（既存21 + 新規14）
- [x] tsc --noEmit 型チェック通過

Closes #16