### PR TITLE
feat(analytics): add Cloudflare Web Analytics

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { locales } from "@/lib/i18n/config";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { GoogleAnalytics } from "@/components/google-analytics";
+import { CfAnalytics } from "@/components/cf-analytics";
 import { CookieConsent } from "@/components/cookie-consent";
 import "../globals.css";
 
@@ -32,6 +33,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
     <html lang={locale}>
       <body className="min-h-screen flex flex-col bg-background text-foreground">
         <GoogleAnalytics />
+        <CfAnalytics />
         <NextIntlClientProvider messages={messages}>
           <Header />
           <main className="flex-1">{children}</main>

--- a/apps/web/src/components/cf-analytics.tsx
+++ b/apps/web/src/components/cf-analytics.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import Script from "next/script";
+
+const CF_ANALYTICS_TOKEN = process.env.NEXT_PUBLIC_CF_ANALYTICS_TOKEN;
+
+export function CfAnalytics() {
+  if (!CF_ANALYTICS_TOKEN) {
+    return null;
+  }
+
+  return (
+    <Script
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      strategy="afterInteractive"
+      data-cf-beacon={JSON.stringify({ token: CF_ANALYTICS_TOKEN })}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add `CfAnalytics` client component that embeds the Cloudflare Web Analytics beacon script
- Token managed via `NEXT_PUBLIC_CF_ANALYTICS_TOKEN` env var (beacon not injected when absent)
- Integrated into `[locale]/layout.tsx` alongside existing `GoogleAnalytics`
- Cookie-free, GDPR-compliant -- no cookie consent required

## Test plan
- [ ] `pnpm --filter web build` passes
- [ ] Without `NEXT_PUBLIC_CF_ANALYTICS_TOKEN` set: beacon script is not rendered
- [ ] With token set: beacon script appears in page source with correct `data-cf-beacon` attribute
- [ ] No cookies are set by the beacon

Closes #50