### PR TITLE
feat(web): display remaining conversion count badge

### DIFF
--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -10,12 +10,33 @@ import { useConversion } from "@/hooks/use-conversion";
 import { useGAEvent } from "@/hooks/use-ga-event";
 import type { ImageFormat } from "@quickconv/shared";
 
+/** Warning threshold: show warning when remaining <= this value */
+const REMAINING_WARNING_THRESHOLD = 3;
+
 export function ConversionCard() {
   const t = useTranslations("common");
   const [file, setFile] = useState<File | null>(null);
   const [outputFormat, setOutputFormat] = useState<ImageFormat | null>(null);
-  const { step, uploadProgress, downloadUrl, error, startConversion, reset, inputFormat, outputFormat: convOutputFormat } = useConversion();
+  const {
+    step,
+    uploadProgress,
+    downloadUrl,
+    error,
+    startConversion,
+    reset,
+    inputFormat,
+    outputFormat: convOutputFormat,
+    remainingConversions,
+    dailyLimit,
+  } = useConversion();
   const { trackFileDownload } = useGAEvent();
+
+  const isRateLimited = remainingConversions !== null && remainingConversions <= 0;
+  const isLowRemaining =
+    remainingConversions !== null &&
+    remainingConversions > 0 &&
+    remainingConversions <= REMAINING_WARNING_THRESHOLD;
+  const hasRateLimitInfo = remainingConversions !== null && dailyLimit !== null;
 
   const handleFileSelect = (selectedFile: File) => {
     setFile(selectedFile);
@@ -24,7 +45,7 @@ export function ConversionCard() {
   };
 
   const handleConvert = () => {
-    if (file && outputFormat) {
+    if (file && outputFormat && !isRateLimited) {
       startConversion(file, outputFormat);
     }
   };
@@ -37,6 +58,41 @@ export function ConversionCard() {
 
   return (
     <div className="w-full max-w-2xl mx-auto space-y-6">
+      {/* Rate Limit Badge */}
+      {hasRateLimitInfo && step === "idle" && (
+        <div className="flex justify-end">
+          <span
+            className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${
+              isRateLimited
+                ? "bg-destructive/10 text-destructive"
+                : isLowRemaining
+                  ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+                  : "bg-muted text-muted-foreground"
+            }`}
+          >
+            {t("remainingCount", { remaining: remainingConversions, limit: dailyLimit })}
+          </span>
+        </div>
+      )}
+
+      {/* Rate Limit Warning */}
+      {step === "idle" && isLowRemaining && (
+        <div className="rounded-lg border border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20 p-3 text-center">
+          <p className="text-sm text-yellow-800 dark:text-yellow-200">
+            {t("remainingWarning")}
+          </p>
+        </div>
+      )}
+
+      {/* Rate Limit Reached */}
+      {step === "idle" && isRateLimited && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-3 text-center">
+          <p className="text-sm text-destructive">
+            {t("rateLimitReached")}
+          </p>
+        </div>
+      )}
+
       {/* Step 1: File Selection */}
       {step === "idle" && (
         <>
@@ -60,7 +116,12 @@ export function ConversionCard() {
           {file && outputFormat && (
             <button
               onClick={handleConvert}
-              className="w-full py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
+              disabled={isRateLimited}
+              className={`w-full py-3 rounded-lg font-medium transition-colors ${
+                isRateLimited
+                  ? "bg-muted text-muted-foreground cursor-not-allowed"
+                  : "bg-primary text-primary-foreground hover:bg-primary/90"
+              }`}
             >
               {t("startConversion")}
             </button>
@@ -95,6 +156,22 @@ export function ConversionCard() {
             <Download className="h-6 w-6 text-green-600" />
           </div>
           <p className="font-medium text-green-600">{t("completed")}</p>
+
+          {/* Show remaining count after conversion */}
+          {hasRateLimitInfo && (
+            <span
+              className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${
+                isRateLimited
+                  ? "bg-destructive/10 text-destructive"
+                  : isLowRemaining
+                    ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+                    : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {t("remainingCount", { remaining: remainingConversions, limit: dailyLimit })}
+            </span>
+          )}
+
           <a
             href={downloadUrl}
             download

--- a/apps/web/src/hooks/use-conversion.ts
+++ b/apps/web/src/hooks/use-conversion.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { uploadFile, requestConversion, checkStatus, getDownloadUrl } from "@/lib/api-client";
+import type { RateLimitInfo } from "@/lib/api-client";
 import { POLLING_INTERVAL_MS } from "@quickconv/shared";
 import type { ImageFormat } from "@quickconv/shared";
 import { useGAEvent } from "./use-ga-event";
@@ -24,10 +25,17 @@ export function useConversion() {
     downloadUrl: null,
     error: null,
   });
+  const [remainingConversions, setRemainingConversions] = useState<number | null>(null);
+  const [dailyLimit, setDailyLimit] = useState<number | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const startTimeRef = useRef<number>(0);
   const formatsRef = useRef<{ from: string; to: string }>({ from: "", to: "" });
   const { trackFileUpload, trackConversionStart, trackConversionComplete, trackConversionError } = useGAEvent();
+
+  const handleRateLimitUpdate = useCallback((info: RateLimitInfo) => {
+    setRemainingConversions(info.remaining);
+    setDailyLimit(info.limit);
+  }, []);
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -45,9 +53,13 @@ export function useConversion() {
 
       try {
         // Step 1: Upload
-        const uploaded = await uploadFile(file, (progress) => {
-          setState((s) => ({ ...s, uploadProgress: progress }));
-        });
+        const uploaded = await uploadFile(
+          file,
+          (progress) => {
+            setState((s) => ({ ...s, uploadProgress: progress }));
+          },
+          handleRateLimitUpdate,
+        );
 
         trackFileUpload(inputFormat, Math.round(file.size / 1024), 1);
 
@@ -56,7 +68,11 @@ export function useConversion() {
         startTimeRef.current = Date.now();
         trackConversionStart(inputFormat, outputFormat);
 
-        const { jobId } = await requestConversion(uploaded.fileId, outputFormat);
+        const { jobId } = await requestConversion(
+          uploaded.fileId,
+          outputFormat,
+          handleRateLimitUpdate,
+        );
         setState((s) => ({ ...s, jobId }));
 
         // Step 3: Poll for status
@@ -100,7 +116,7 @@ export function useConversion() {
         }));
       }
     },
-    [stopPolling, trackFileUpload, trackConversionStart, trackConversionComplete, trackConversionError]
+    [stopPolling, handleRateLimitUpdate, trackFileUpload, trackConversionStart, trackConversionComplete, trackConversionError]
   );
 
   const reset = useCallback(() => {
@@ -108,5 +124,13 @@ export function useConversion() {
     setState({ step: "idle", uploadProgress: 0, jobId: null, downloadUrl: null, error: null });
   }, [stopPolling]);
 
-  return { ...state, startConversion, reset, inputFormat: formatsRef.current.from, outputFormat: formatsRef.current.to };
+  return {
+    ...state,
+    startConversion,
+    reset,
+    inputFormat: formatsRef.current.from,
+    outputFormat: formatsRef.current.to,
+    remainingConversions,
+    dailyLimit,
+  };
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -2,9 +2,26 @@ import type { UploadResponse, ConvertResponse, StatusResponse } from "@quickconv
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8787";
 
+/** Rate limit info extracted from API response headers */
+export interface RateLimitInfo {
+  remaining: number;
+  limit: number;
+}
+
+/** Extract X-RateLimit-* headers from fetch Response */
+function extractRateLimitFromFetch(res: Response): RateLimitInfo | null {
+  const remaining = res.headers.get("X-RateLimit-Remaining");
+  const limit = res.headers.get("X-RateLimit-Limit");
+  if (remaining !== null && limit !== null) {
+    return { remaining: Number(remaining), limit: Number(limit) };
+  }
+  return null;
+}
+
 export async function uploadFile(
   file: File,
-  onProgress?: (progress: number) => void
+  onProgress?: (progress: number) => void,
+  onRateLimit?: (info: RateLimitInfo) => void,
 ): Promise<UploadResponse> {
   const formData = new FormData();
   formData.append("file", file);
@@ -22,6 +39,12 @@ export async function uploadFile(
 
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
+        // Extract rate limit info from response headers
+        const remaining = xhr.getResponseHeader("X-RateLimit-Remaining");
+        const limit = xhr.getResponseHeader("X-RateLimit-Limit");
+        if (remaining !== null && limit !== null && onRateLimit) {
+          onRateLimit({ remaining: Number(remaining), limit: Number(limit) });
+        }
         resolve(JSON.parse(xhr.responseText));
       } else {
         reject(new Error(JSON.parse(xhr.responseText).message || "Upload failed"));
@@ -35,7 +58,8 @@ export async function uploadFile(
 
 export async function requestConversion(
   fileId: string,
-  outputFormat: string
+  outputFormat: string,
+  onRateLimit?: (info: RateLimitInfo) => void,
 ): Promise<ConvertResponse> {
   const res = await fetch(`${API_URL}/api/convert`, {
     method: "POST",
@@ -48,7 +72,19 @@ export async function requestConversion(
     throw new Error(error.message || "Conversion request failed");
   }
 
-  return res.json();
+  const data = await res.json();
+
+  // Extract rate limit from headers first, fall back to response body
+  if (onRateLimit) {
+    const headerRateLimit = extractRateLimitFromFetch(res);
+    if (headerRateLimit) {
+      onRateLimit(headerRateLimit);
+    } else if (data.remainingConversions !== undefined && data.dailyLimit !== undefined) {
+      onRateLimit({ remaining: data.remainingConversions, limit: data.dailyLimit });
+    }
+  }
+
+  return data;
 }
 
 export async function checkStatus(jobId: string): Promise<StatusResponse> {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -28,7 +28,10 @@
     "popularConversions": "Popular Conversions",
     "popularConversionsDescription": "Most used image conversion tools",
     "convertFromTo": "{from} to {to}",
-    "footerConversions": "Conversions"
+    "footerConversions": "Conversions",
+    "remainingCount": "{remaining}/{limit} left today",
+    "remainingWarning": "Running low on free conversions today.",
+    "rateLimitReached": "Daily limit reached. Try again tomorrow."
   },
   "seo": {
     "homeTitle": "QuickConv - Free Online Image Converter | WebP AVIF HEIC",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -28,7 +28,10 @@
     "popularConversions": "人気の変換",
     "popularConversionsDescription": "よく使われている画像変換ツール",
     "convertFromTo": "{from}から{to}",
-    "footerConversions": "変換ツール"
+    "footerConversions": "変換ツール",
+    "remainingCount": "残り {remaining}/{limit} 回",
+    "remainingWarning": "本日の無料変換回数が残りわずかです。",
+    "rateLimitReached": "本日の変換回数の上限に達しました。明日またお試しください。"
   },
   "seo": {
     "homeTitle": "QuickConv - 無料オンライン画像変換 | WebP AVIF HEIC対応",


### PR DESCRIPTION
## Summary
- Extract rate limit info from API response headers (`X-RateLimit-Remaining`, `X-RateLimit-Limit`) and convert response body
- Add `remainingConversions` / `dailyLimit` state management to `useConversion` hook
- Display remaining count badge near convert button: normal (gray), warning (yellow at <= 3), disabled (red at 0)
- Disable convert button when daily limit reached
- i18n support (en/ja) for all rate limit messages

## Changed Files
- `apps/web/src/lib/api-client.ts` - Added `onRateLimit` callback to `uploadFile` and `requestConversion`
- `apps/web/src/hooks/use-conversion.ts` - Added rate limit state and callback wiring
- `apps/web/src/components/conversion-card.tsx` - Badge, warning, button disable UI
- `apps/web/src/messages/en.json` / `ja.json` - Added `remainingCount`, `remainingWarning`, `rateLimitReached`

## Test plan
- [ ] Verify badge appears after first conversion with correct remaining/limit count
- [ ] Verify badge turns yellow/orange when remaining <= 3
- [ ] Verify convert button is disabled and error message shows when remaining = 0
- [ ] Verify Japanese locale shows correct translated messages
- [ ] Verify no TypeScript errors in changed files

Closes #18