### PR TITLE
chore: 並列セッション保護（in-progress ラベル自動管理）

### DIFF
--- a/.github/workflows/project-dates.yml
+++ b/.github/workflows/project-dates.yml
@@ -9,7 +9,7 @@ on:
     types: [edited]
 
 permissions:
-  issues: read
+  issues: write
   pull-requests: read
   repository-projects: write
 
@@ -166,4 +166,8 @@ jobs:
             ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID"
 
             echo "Set status to Done for issue #$ISSUE_NUM"
+
+            # Remove in-progress label
+            gh issue edit "$ISSUE_NUM" --remove-label "in-progress" -R "$REPO" 2>/dev/null || true
+            echo "Removed in-progress label from issue #$ISSUE_NUM"
           done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@
 1. Issue解析 → 2. 実装 → 3. E2Eテスト（Playwright, `apps/web/e2e/`） → 4. Push → 5. PR（`Closes #XX` 必須）
 - 並列開発: 別ブランチで作業。依存関係マップ参照
 - AC検証: 競合（Convertio/iLoveIMG/TinyPNG）と同等動作を基準
+- **着手時**: `gh issue edit <N> --add-label in-progress`（`in-progress` があれば他セッションが作業中）
+- **PR マージ時**: GitHub Actions が `in-progress` を自動除去
 
 ## ビルド・デプロイ
 詳細: [docs/deploy.md](docs/deploy.md)


### PR DESCRIPTION
## Summary
- Issue 着手時に `in-progress` ラベルを付与する規約を追加
- PR マージ時に `in-progress` ラベルを自動除去（GitHub Actions）
- 並列エージェントセッション間の作業バッティングを防止

## 仕組み
1. エージェントが Issue 着手時 → `gh issue edit <N> --add-label in-progress`
2. 別セッションが同じ Issue を取ろうとした際 → `in-progress` ラベルを見てスキップ
3. PR マージ時 → `Closes #XX` の Issue から `in-progress` を自動除去

## Test plan
- [ ] `in-progress` ラベルが存在する
- [ ] project-dates.yml の issues permission が `write`
- [ ] PR マージ時にラベル除去ステップが実行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)