### PR TITLE
feat(ads): add AdBanner and AdSlot components

### DIFF
--- a/apps/web/src/components/ad-banner.tsx
+++ b/apps/web/src/components/ad-banner.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import Script from "next/script";
+import { useEffect, useRef, useState } from "react";
+
+/** Global flag to enable/disable all ads (for maintenance or AdSense review). */
+const ADS_ENABLED = process.env.NEXT_PUBLIC_ADS_ENABLED !== "false";
+
+const ADSENSE_CLIENT_ID = process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID;
+
+type AdFormat = "auto" | "rectangle" | "leaderboard" | "mobile-banner";
+
+interface AdBannerProps {
+  /** AdSense ad unit slot ID */
+  slot: string;
+  /** Ad format */
+  format?: AdFormat;
+  /** Additional CSS classes */
+  className?: string;
+  /** Lazy load the ad (default: true) */
+  lazy?: boolean;
+}
+
+const FORMAT_STYLES: Record<AdFormat, { width: string; height: string }> = {
+  auto: { width: "100%", height: "auto" },
+  rectangle: { width: "300px", height: "250px" },
+  leaderboard: { width: "728px", height: "90px" },
+  "mobile-banner": { width: "320px", height: "50px" },
+};
+
+const FORMAT_MIN_HEIGHTS: Record<AdFormat, string> = {
+  auto: "90px",
+  rectangle: "250px",
+  leaderboard: "90px",
+  "mobile-banner": "50px",
+};
+
+declare global {
+  interface Window {
+    adsbygoogle?: Record<string, unknown>[];
+  }
+}
+
+function AdSkeleton({ format }: { format: AdFormat }) {
+  const minHeight = FORMAT_MIN_HEIGHTS[format];
+  return (
+    <div
+      className="animate-pulse bg-muted/40 rounded"
+      style={{ minHeight, width: "100%" }}
+      aria-hidden="true"
+    />
+  );
+}
+
+export function AdBanner({
+  slot,
+  format = "auto",
+  className,
+  lazy = true,
+}: AdBannerProps) {
+  const adRef = useRef<HTMLModElement>(null);
+  const [adLoaded, setAdLoaded] = useState(false);
+  const [adError, setAdError] = useState(false);
+  const pushed = useRef(false);
+
+  // Don't render if ads are disabled or client ID is missing
+  if (!ADS_ENABLED || !ADSENSE_CLIENT_ID) {
+    return null;
+  }
+
+  const style = FORMAT_STYLES[format];
+  const adStyle =
+    format === "auto"
+      ? { display: "block" }
+      : { display: "inline-block", width: style.width, height: style.height };
+
+  // Push ad after script is loaded
+  useEffect(() => {
+    if (pushed.current) return;
+
+    const tryPush = () => {
+      try {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+        pushed.current = true;
+        setAdLoaded(true);
+      } catch {
+        setAdError(true);
+      }
+    };
+
+    // If adsbygoogle is already available, push immediately
+    if (window.adsbygoogle) {
+      tryPush();
+      return;
+    }
+
+    // Otherwise wait for script load event
+    const handleLoad = () => tryPush();
+    window.addEventListener("adsense-loaded", handleLoad);
+    return () => window.removeEventListener("adsense-loaded", handleLoad);
+  }, []);
+
+  // Detect ad blocker: if ins element has 0 height after a delay, ads are blocked
+  useEffect(() => {
+    if (!adLoaded) return;
+
+    const timer = setTimeout(() => {
+      const el = adRef.current;
+      if (el && el.offsetHeight === 0) {
+        setAdError(true);
+      }
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [adLoaded]);
+
+  // Ad blocked or errored: render empty space to prevent CLS
+  if (adError) {
+    return (
+      <div
+        className={className}
+        style={{ minHeight: FORMAT_MIN_HEIGHTS[format] }}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return (
+    <div className={className}>
+      {/* AdSense script (loaded once globally via next/script) */}
+      <Script
+        id="adsense-script"
+        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT_ID}`}
+        strategy="lazyOnload"
+        crossOrigin="anonymous"
+        onLoad={() => {
+          window.dispatchEvent(new Event("adsense-loaded"));
+        }}
+        onError={() => setAdError(true)}
+      />
+
+      {/* Skeleton while loading */}
+      {!adLoaded && !adError && <AdSkeleton format={format} />}
+
+      {/* AdSense ad unit */}
+      <ins
+        ref={adRef}
+        className="adsbygoogle"
+        style={{
+          ...adStyle,
+          ...(adLoaded ? {} : { position: "absolute", opacity: 0 }),
+        }}
+        data-ad-client={ADSENSE_CLIENT_ID}
+        data-ad-slot={slot}
+        data-ad-format={format === "auto" ? "auto" : undefined}
+        data-full-width-responsive={format === "auto" ? "true" : undefined}
+        {...(lazy ? { "data-ad-loading": "lazy" } : {})}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/ad-slot.tsx
+++ b/apps/web/src/components/ad-slot.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { AdBanner } from "./ad-banner";
+
+type AdPlacement = "leaderboard" | "rectangle" | "mobile-banner";
+
+interface AdSlotProps {
+  /** AdSense ad unit slot ID */
+  slot: string;
+  /** Placement type (determines responsive behavior) */
+  placement: AdPlacement;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Responsive ad slot helper.
+ *
+ * - "leaderboard": 728x90 on desktop, 320x50 on mobile
+ * - "rectangle": 300x250 (all sizes)
+ * - "mobile-banner": 320x50 (mobile only, hidden on desktop)
+ */
+export function AdSlot({ slot, placement, className }: AdSlotProps) {
+  if (placement === "leaderboard") {
+    return (
+      <div className={className}>
+        {/* Desktop: 728x90 leaderboard */}
+        <div className="hidden md:flex justify-center">
+          <AdBanner slot={slot} format="leaderboard" />
+        </div>
+        {/* Mobile: 320x50 banner */}
+        <div className="flex md:hidden justify-center">
+          <AdBanner slot={slot} format="mobile-banner" />
+        </div>
+      </div>
+    );
+  }
+
+  if (placement === "rectangle") {
+    return (
+      <div className={`flex justify-center ${className ?? ""}`}>
+        <AdBanner slot={slot} format="rectangle" />
+      </div>
+    );
+  }
+
+  // mobile-banner: only shown on small screens
+  return (
+    <div className={`flex md:hidden justify-center ${className ?? ""}`}>
+      <AdBanner slot={slot} format="mobile-banner" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **AdBanner** (`ad-banner.tsx`): Core AdSense ad component with skeleton loading (CLS prevention), ad blocker detection/fallback, global ON/OFF flag (`NEXT_PUBLIC_ADS_ENABLED`), lazy loading, and env-based client ID (`NEXT_PUBLIC_ADSENSE_CLIENT_ID`)
- **AdSlot** (`ad-slot.tsx`): Responsive placement helper -- leaderboard (728x90) on desktop / mobile banner (320x50) on small screens, plus rectangle (300x250)

Closes #24

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` (static export) succeeds
- [ ] Visual confirmation: skeleton shown when ads load
- [ ] Verify no render when `NEXT_PUBLIC_ADSENSE_CLIENT_ID` is unset
- [ ] Verify `NEXT_PUBLIC_ADS_ENABLED=false` hides all ads