### PR TITLE
feat(web): お問い合わせページ追加（AdSense準備）

### DIFF
--- a/apps/web/src/app/[locale]/contact/page.tsx
+++ b/apps/web/src/app/[locale]/contact/page.tsx
@@ -1,0 +1,74 @@
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Breadcrumb } from "@/components/breadcrumb";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { locales, type Locale } from "@/lib/i18n/config";
+import { buildPageMetadata } from "@/lib/metadata";
+import type { Metadata } from "next";
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "seo" });
+
+  return buildPageMetadata({
+    title: t("contactTitle"),
+    description: t("contactDescription"),
+    locale: locale as Locale,
+    path: "/contact",
+  });
+}
+
+export default async function ContactPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("contact");
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12">
+      <BreadcrumbJsonLd
+        locale={locale as Locale}
+        items={[{ name: t("title") }]}
+      />
+      <Breadcrumb items={[{ label: t("title") }]} />
+      <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
+      <p className="mt-6 text-muted-foreground">{t("intro")}</p>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("emailTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">{t("emailDescription")}</p>
+        <p className="mt-2">
+          <a
+            href="mailto:support@quickconv.cc"
+            className="text-primary hover:underline font-medium"
+          >
+            support@quickconv.cc
+          </a>
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("responseTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">
+          {t("responseDescription")}
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">{t("operatorTitle")}</h2>
+        <p className="mt-2 text-muted-foreground">{t("operatorName")}</p>
+        <p className="mt-1 text-muted-foreground">{t("operatorService")}</p>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -58,6 +58,14 @@ export function Footer() {
               </li>
               <li>
                 <Link
+                  href="/contact"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t("contact")}
+                </Link>
+              </li>
+              <li>
+                <Link
                   href="/guide"
                   className="text-muted-foreground hover:text-foreground transition-colors"
                 >

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -34,6 +34,7 @@
     "rateLimitReached": "Daily limit reached. Try again tomorrow.",
     "batchLimitExceeded": "You can convert up to {limit} files at a time. Only the first file was selected.",
     "batchLimitByRemaining": "You only have {count} conversion(s) left today. Only the first file was selected.",
+    "contact": "Contact",
     "guide": "Guide",
     "guideDescription": "Learn about next-generation image formats and how to convert them",
     "readMore": "Read more",
@@ -56,7 +57,20 @@
     "guideHeicToJpgTitle": "3 Ways to Convert iPhone HEIC Photos to JPG | QuickConv",
     "guideHeicToJpgDescription": "Convert HEIC photos from iPhone to JPG easily. Compare three conversion methods: online tools, macOS Preview, and mobile apps.",
     "guideWebpVsAvifVsHeicTitle": "WebP vs AVIF vs HEIC: Next-Gen Image Format Comparison | QuickConv",
-    "guideWebpVsAvifVsHeicDescription": "Compare WebP, AVIF, and HEIC image formats. Learn the differences in compression, quality, browser support, and which format to use."
+    "guideWebpVsAvifVsHeicDescription": "Compare WebP, AVIF, and HEIC image formats. Learn the differences in compression, quality, browser support, and which format to use.",
+    "contactTitle": "Contact Us | QuickConv",
+    "contactDescription": "Get in touch with the QuickConv team. We're here to help with any questions about our free online image conversion service."
+  },
+  "contact": {
+    "title": "Contact Us",
+    "intro": "Have a question, suggestion, or issue? We'd love to hear from you. Please reach out using the information below.",
+    "emailTitle": "Email",
+    "emailDescription": "For general inquiries, bug reports, or feature requests:",
+    "responseTitle": "Response Time",
+    "responseDescription": "We typically respond within 1-2 business days. For urgent issues, please include 'URGENT' in your subject line.",
+    "operatorTitle": "Service Operator",
+    "operatorName": "QuickConv",
+    "operatorService": "Online Image Conversion Service — quickconv.cc"
   },
   "cookieConsent": {
     "message": "This website uses cookies to provide you with a better experience. We use cookies for rate limiting and service improvement.",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -34,6 +34,7 @@
     "rateLimitReached": "本日の変換回数の上限に達しました。明日またお試しください。",
     "batchLimitExceeded": "一度に変換できるのは{limit}枚までです。最初のファイルのみ選択されました。",
     "batchLimitByRemaining": "本日の残り変換回数は{count}回です。最初のファイルのみ選択されました。",
+    "contact": "お問い合わせ",
     "guide": "ガイド",
     "guideDescription": "次世代画像フォーマットについて学び、効率的に変換する方法を紹介します",
     "readMore": "続きを読む",
@@ -56,7 +57,20 @@
     "guideHeicToJpgTitle": "iPhoneのHEIC写真をJPGに変換する3つの方法 | QuickConv",
     "guideHeicToJpgDescription": "iPhoneのHEIC写真をJPGに簡単変換。オンラインツール、macOSプレビュー、アプリの3つの方法を比較。",
     "guideWebpVsAvifVsHeicTitle": "WebP vs AVIF vs HEIC：次世代画像フォーマット比較 | QuickConv",
-    "guideWebpVsAvifVsHeicDescription": "WebP、AVIF、HEICの画像フォーマットを徹底比較。圧縮率、品質、ブラウザ対応、用途別の推奨フォーマットを解説。"
+    "guideWebpVsAvifVsHeicDescription": "WebP、AVIF、HEICの画像フォーマットを徹底比較。圧縮率、品質、ブラウザ対応、用途別の推奨フォーマットを解説。",
+    "contactTitle": "お問い合わせ | QuickConv",
+    "contactDescription": "QuickConvへのお問い合わせ。無料オンライン画像変換サービスに関するご質問にお答えします。"
+  },
+  "contact": {
+    "title": "お問い合わせ",
+    "intro": "ご質問、ご提案、問題のご報告がございましたら、以下の連絡先までお気軽にお問い合わせください。",
+    "emailTitle": "メール",
+    "emailDescription": "一般的なお問い合わせ、バグ報告、機能リクエストはこちら：",
+    "responseTitle": "返信目安",
+    "responseDescription": "通常1〜2営業日以内に返信いたします。お急ぎの場合は、件名に「至急」とご記載ください。",
+    "operatorTitle": "サービス運営者",
+    "operatorName": "QuickConv",
+    "operatorService": "オンライン画像変換サービス — quickconv.cc"
   },
   "cookieConsent": {
     "message": "当サイトでは、より良いサービスを提供するためにCookieを使用しています。レート制限およびサービス改善の目的で使用されます。",


### PR DESCRIPTION
## Summary
- `/contact` ページ追加（メール連絡先、返信目安、サービス運営者情報）
- フッターに Contact リンク追加（Privacy → Terms → Contact → Guide）
- i18n 対応（日英）
- SEO メタデータ設定

## AdSense ポリシー対応
- [x] サービス運営者情報の掲載
- [x] 連絡先の明示
- [x] プライバシーポリシー（既存）
- [x] 利用規約（既存）

## Test plan
- [ ] `/en/contact` が表示される
- [ ] `/ja/contact` が日本語で表示される
- [ ] フッターから contact ページへ遷移可能
- [ ] meta title/description が設定されている

Closes #22
Part of #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)