### PR TITLE
feat(ads): hide ads for paid users

### DIFF
--- a/apps/web/src/components/ad-banner.tsx
+++ b/apps/web/src/components/ad-banner.tsx
@@ -2,6 +2,7 @@
 
 import Script from "next/script";
 import { useEffect, useRef, useState } from "react";
+import { useSubscription } from "@/hooks/use-subscription";
 
 /** Global flag to enable/disable all ads (for maintenance or AdSense review). */
 const ADS_ENABLED = process.env.NEXT_PUBLIC_ADS_ENABLED !== "false";
@@ -62,9 +63,20 @@ export function AdBanner({
   const [adLoaded, setAdLoaded] = useState(false);
   const [adError, setAdError] = useState(false);
   const pushed = useRef(false);
+  const { isPaid, isLoading: subscriptionLoading } = useSubscription();
 
   // Don't render if ads are disabled or client ID is missing
   if (!ADS_ENABLED || !ADSENSE_CLIENT_ID) {
+    return null;
+  }
+
+  // Hide ads for paid users (pass or subscription)
+  if (isPaid) {
+    return null;
+  }
+
+  // Don't render while checking subscription to prevent ad flash
+  if (subscriptionLoading) {
     return null;
   }
 

--- a/apps/web/src/hooks/use-subscription.ts
+++ b/apps/web/src/hooks/use-subscription.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * User subscription plan types.
+ *
+ * - "free"  : No active subscription or pass
+ * - "pass"  : 7-day pass (one-time purchase)
+ * - "plus"  : Plus monthly subscription
+ * - "pro"   : Pro monthly subscription
+ */
+export type Plan = "free" | "pass" | "plus" | "pro";
+
+interface SubscriptionState {
+  /** Current plan. Defaults to "free". */
+  plan: Plan;
+  /** Whether the user has any paid plan (pass or subscription). */
+  isPaid: boolean;
+  /** Whether the subscription data is still loading. */
+  isLoading: boolean;
+  /** Expiration date for time-limited plans (pass). null if N/A. */
+  expiresAt: Date | null;
+}
+
+/**
+ * Hook to manage user subscription state.
+ *
+ * Current implementation: **STUB** (always returns free plan).
+ *
+ * When E3 (Stripe integration) is implemented, replace the stub
+ * fetch with a real call to `/api/me` that returns:
+ * ```json
+ * { "plan": "plus", "expiresAt": null }
+ * ```
+ *
+ * For passes:
+ * ```json
+ * { "plan": "pass", "expiresAt": "2026-03-22T00:00:00Z" }
+ * ```
+ */
+export function useSubscription(): SubscriptionState {
+  const [plan, setPlan] = useState<Plan>("free");
+  const [expiresAt, setExpiresAt] = useState<Date | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchSubscription = useCallback(async () => {
+    try {
+      // ── STUB: Replace with real API call when E3 is ready ──
+      // const res = await fetch("/api/me");
+      // if (!res.ok) throw new Error("Failed to fetch subscription");
+      // const data = await res.json();
+      // setPlan(data.plan ?? "free");
+      // setExpiresAt(data.expiresAt ? new Date(data.expiresAt) : null);
+
+      // Stub: always free
+      setPlan("free");
+      setExpiresAt(null);
+    } catch {
+      // On error, default to free (ads shown) — fail-open for monetization
+      setPlan("free");
+      setExpiresAt(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSubscription();
+  }, [fetchSubscription]);
+
+  // Check if a pass has expired
+  const isExpired = expiresAt !== null && expiresAt.getTime() < Date.now();
+  const effectivePlan: Plan = isExpired ? "free" : plan;
+  const isPaid = effectivePlan !== "free";
+
+  return {
+    plan: effectivePlan,
+    isPaid,
+    isLoading,
+    expiresAt,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useSubscription` hook (stub) returning `plan`, `isPaid`, `isLoading`, `expiresAt`
- Modify `AdBanner` to hide ads when `isPaid === true`, and suppress rendering during `isLoading` to prevent ad flash
- Pass expiration logic: when `expiresAt` is past, plan reverts to `free` and ads reappear

## Design
- `useSubscription` is a complete stub (`isPaid: false` always) until E3 (Stripe) implements `/api/me`
- E3 integration requires only uncommenting the fetch call and removing the stub values
- Fail-open strategy: on API error, defaults to `free` (ads shown) to protect monetization

## Test plan
- [x] TypeScript type check passes
- [x] Build compilation succeeds (66 static pages generated)
- [ ] Manual: verify ads still render for free users (stub always returns free)
- [ ] Manual: change stub to `setPlan("plus")` and verify ads disappear
- [ ] Manual: set `expiresAt` to past date with plan "pass" and verify ads reappear

Closes #26