### PR TITLE
feat(ads): add ad placements to conversion card and layout

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { GoogleAnalytics } from "@/components/google-analytics";
 import { CfAnalytics } from "@/components/cf-analytics";
 import { CookieConsent } from "@/components/cookie-consent";
 import { OrganizationJsonLd } from "@/components/json-ld";
+import { AdSlot } from "@/components/ad-slot";
 import "../globals.css";
 
 export function generateStaticParams() {
@@ -45,6 +46,10 @@ export default async function LocaleLayout({
         <NextIntlClientProvider messages={messages}>
           <Header />
           <main className="flex-1">{children}</main>
+          {/* Ad: Leaderboard above footer */}
+          <div className="max-w-5xl mx-auto px-4 py-4">
+            <AdSlot slot="footer-leaderboard" placement="leaderboard" />
+          </div>
           <Footer />
           <CookieConsent />
           <Toaster position="top-center" richColors />

--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -8,6 +8,7 @@ import { FormatSelector } from "./format-selector";
 import { ProgressBar } from "./progress-bar";
 import { UpgradeModal } from "./upgrade-modal";
 import { UpgradeBanner } from "./upgrade-banner";
+import { AdSlot } from "./ad-slot";
 import { useConversion } from "@/hooks/use-conversion";
 import { useGAEvent } from "@/hooks/use-ga-event";
 import type { ImageFormat } from "@quickconv/shared";
@@ -130,6 +131,9 @@ export function ConversionCard() {
               {t("startConversion")}
             </button>
           )}
+
+          {/* Ad: Leaderboard below tool description (idle state) */}
+          <AdSlot slot="idle-leaderboard" placement="leaderboard" className="mt-6" />
         </>
       )}
 
@@ -144,13 +148,17 @@ export function ConversionCard() {
 
       {/* Step 3: Converting */}
       {step === "converting" && (
-        <div className="rounded-xl border border-border p-8 text-center space-y-4">
-          <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
-          <p className="font-medium">{t("processing")}</p>
-          <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
-            <div className="h-full rounded-full bg-primary animate-pulse w-full" />
+        <>
+          <div className="rounded-xl border border-border p-8 text-center space-y-4">
+            <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
+            <p className="font-medium">{t("processing")}</p>
+            <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+              <div className="h-full rounded-full bg-primary animate-pulse w-full" />
+            </div>
           </div>
-        </div>
+          {/* Ad: Leaderboard during conversion (user waits here) */}
+          <AdSlot slot="converting-leaderboard" placement="leaderboard" className="mt-4" />
+        </>
       )}
 
       {/* Step 4: Completed */}
@@ -175,6 +183,9 @@ export function ConversionCard() {
               {t("remainingCount", { remaining: remainingConversions, limit: dailyLimit })}
             </span>
           )}
+
+          {/* Ad: Rectangle above download button */}
+          <AdSlot slot="completed-rectangle" placement="rectangle" className="my-2" />
 
           <a
             href={downloadUrl}


### PR DESCRIPTION
## Summary
- Add AdSlot leaderboard (728x90 desktop / 320x50 mobile) below tool description in idle state
- Add AdSlot leaderboard during conversion (converting state) for user wait time monetization
- Add AdSlot rectangle (300x250) above download button in completed state
- Add AdSlot leaderboard above footer in layout (all pages)

## Ad Placement Map
| Location | Format | Desktop | Mobile |
|---|---|---|---|
| Idle (below dropzone) | leaderboard | 728x90 | 320x50 |
| Converting (below progress) | leaderboard | 728x90 | 320x50 |
| Completed (above DL button) | rectangle | 300x250 | 300x250 |
| Footer (all pages) | leaderboard | 728x90 | 320x50 |

## CLS Prevention
- AdBanner already reserves `min-height` via skeleton placeholder
- Ads render nothing when `NEXT_PUBLIC_ADSENSE_CLIENT_ID` is not set

Closes #25

## Test plan
- [ ] Build succeeds (`pnpm --filter web build`)
- [ ] Idle state shows leaderboard ad below dropzone area
- [ ] Converting state shows leaderboard ad below progress indicator
- [ ] Completed state shows rectangle ad above download button
- [ ] Footer leaderboard appears on all pages
- [ ] Mobile viewport shows 320x50 banner instead of 728x90
- [ ] Ads do not overlap upload area or download button
- [ ] No CLS regression (ad slots reserve space with min-height)