### PR TITLE
feat(ads): RPM optimization with A/B test and GA4 ad tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 NEXT_PUBLIC_API_URL=http://localhost:8787
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
+# Ad layout A/B test: "default" | "variant-a" | "variant-b"
+NEXT_PUBLIC_AD_LAYOUT=default
+
 # Converter (Cloud Run)
 API_KEY=your-secret-api-key
 R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -38,6 +38,14 @@ export default async function LocaleLayout({
   return (
     <html lang={locale}>
       <head>
+        <meta
+          name="keywords"
+          content="image converter, file conversion, HEIC, WebP, AVIF, PNG, JPG, online converter"
+        />
+        <meta
+          name="category"
+          content="image converter, file conversion, HEIC, WebP, AVIF"
+        />
         <OrganizationJsonLd />
       </head>
       <body className="min-h-screen flex flex-col bg-background text-foreground">

--- a/apps/web/src/components/ad-banner.tsx
+++ b/apps/web/src/components/ad-banner.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Script from "next/script";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSubscription } from "@/hooks/use-subscription";
+import { AD_LAYOUT } from "@/lib/ad-layout";
 
 /** Global flag to enable/disable all ads (for maintenance or AdSense review). */
 const ADS_ENABLED = process.env.NEXT_PUBLIC_ADS_ENABLED !== "false";
@@ -40,6 +41,26 @@ declare global {
   interface Window {
     adsbygoogle?: Record<string, unknown>[];
   }
+}
+
+/** Send a GA4 custom event for ad performance measurement. */
+function sendAdEvent(
+  eventName: "ad_impression" | "ad_click",
+  slot: string,
+  format: AdFormat,
+): void {
+  if (typeof window === "undefined") return;
+  if (typeof window.gtag !== "function") return;
+  try {
+    if (localStorage.getItem("qc_cookie_consent") !== "accepted") return;
+  } catch {
+    return;
+  }
+  window.gtag("event", eventName, {
+    ad_slot: slot,
+    ad_format: format,
+    ad_layout: AD_LAYOUT,
+  });
 }
 
 function AdSkeleton({ format }: { format: AdFormat }) {
@@ -126,6 +147,33 @@ export function AdBanner({
     return () => clearTimeout(timer);
   }, [adLoaded]);
 
+  // GA4: Track ad_impression when the ad enters the viewport (50%+ visible)
+  const impressionFired = useRef(false);
+  useEffect(() => {
+    if (!adLoaded || impressionFired.current) return;
+    const el = adRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !impressionFired.current) {
+          impressionFired.current = true;
+          sendAdEvent("ad_impression", slot, format);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [adLoaded, slot, format]);
+
+  // GA4: Track ad_click when the ad container is clicked
+  const handleAdClick = useCallback(() => {
+    sendAdEvent("ad_click", slot, format);
+  }, [slot, format]);
+
   // Ad blocked or errored: render empty space to prevent CLS
   if (adError) {
     return (
@@ -138,7 +186,8 @@ export function AdBanner({
   }
 
   return (
-    <div className={className}>
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div className={className} onClick={handleAdClick}>
       {/* AdSense script (loaded once globally via next/script) */}
       <Script
         id="adsense-script"

--- a/apps/web/src/components/ad-slot.tsx
+++ b/apps/web/src/components/ad-slot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AdBanner } from "./ad-banner";
+import { getAdSlotConfig } from "@/lib/ad-layout";
 
 type AdPlacement = "leaderboard" | "rectangle" | "mobile-banner";
 
@@ -14,13 +15,23 @@ interface AdSlotProps {
 }
 
 /**
- * Responsive ad slot helper.
+ * Responsive ad slot helper with A/B test support.
+ *
+ * The slot is conditionally rendered based on NEXT_PUBLIC_AD_LAYOUT.
+ * When disabled by the layout config, nothing is rendered.
  *
  * - "leaderboard": 728x90 on desktop, 320x50 on mobile
  * - "rectangle": 300x250 (all sizes)
  * - "mobile-banner": 320x50 (mobile only, hidden on desktop)
  */
 export function AdSlot({ slot, placement, className }: AdSlotProps) {
+  const config = getAdSlotConfig(slot);
+
+  // If the layout config disables this slot, don't render
+  if (!config.enabled) {
+    return null;
+  }
+
   if (placement === "leaderboard") {
     return (
       <div className={className}>

--- a/apps/web/src/lib/ad-layout.ts
+++ b/apps/web/src/lib/ad-layout.ts
@@ -1,0 +1,83 @@
+/**
+ * A/B test ad layout configuration.
+ *
+ * Controlled via the NEXT_PUBLIC_AD_LAYOUT environment variable.
+ * - "default"  : baseline layout (current placements)
+ * - "variant-a" : leaderboard above and below main content
+ * - "variant-b" : rectangle-heavy layout (more 300x250 units)
+ *
+ * Unrecognised values fall back to "default".
+ */
+
+export type AdLayout = "default" | "variant-a" | "variant-b";
+
+const VALID_LAYOUTS: readonly AdLayout[] = [
+  "default",
+  "variant-a",
+  "variant-b",
+] as const;
+
+function resolveLayout(): AdLayout {
+  const raw = process.env.NEXT_PUBLIC_AD_LAYOUT ?? "default";
+  return VALID_LAYOUTS.includes(raw as AdLayout)
+    ? (raw as AdLayout)
+    : "default";
+}
+
+/** Current ad layout selected by the environment variable. */
+export const AD_LAYOUT: AdLayout = resolveLayout();
+
+export interface AdPlacementConfig {
+  /** Whether the slot is enabled in this layout. */
+  enabled: boolean;
+  /** Placement type. */
+  placement: "leaderboard" | "rectangle" | "mobile-banner";
+}
+
+type SlotName =
+  | "idle-leaderboard"
+  | "converting-leaderboard"
+  | "completed-rectangle"
+  | "footer-leaderboard"
+  | "sidebar-rectangle";
+
+/**
+ * Per-layout configuration for each ad slot.
+ *
+ * When a slot is disabled it will not render, enabling quick A/B
+ * testing without touching component code.
+ */
+const LAYOUT_CONFIGS: Record<AdLayout, Record<SlotName, AdPlacementConfig>> = {
+  default: {
+    "idle-leaderboard": { enabled: true, placement: "leaderboard" },
+    "converting-leaderboard": { enabled: true, placement: "leaderboard" },
+    "completed-rectangle": { enabled: true, placement: "rectangle" },
+    "footer-leaderboard": { enabled: true, placement: "leaderboard" },
+    "sidebar-rectangle": { enabled: false, placement: "rectangle" },
+  },
+  "variant-a": {
+    "idle-leaderboard": { enabled: true, placement: "leaderboard" },
+    "converting-leaderboard": { enabled: true, placement: "leaderboard" },
+    "completed-rectangle": { enabled: false, placement: "rectangle" },
+    "footer-leaderboard": { enabled: true, placement: "leaderboard" },
+    "sidebar-rectangle": { enabled: false, placement: "rectangle" },
+  },
+  "variant-b": {
+    "idle-leaderboard": { enabled: false, placement: "leaderboard" },
+    "converting-leaderboard": { enabled: true, placement: "leaderboard" },
+    "completed-rectangle": { enabled: true, placement: "rectangle" },
+    "footer-leaderboard": { enabled: true, placement: "leaderboard" },
+    "sidebar-rectangle": { enabled: true, placement: "rectangle" },
+  },
+};
+
+/**
+ * Retrieve the configuration for a specific ad slot.
+ * Returns `{ enabled: false }` for unknown slot names.
+ */
+export function getAdSlotConfig(slotName: string): AdPlacementConfig {
+  const config = LAYOUT_CONFIGS[AD_LAYOUT];
+  return (
+    config[slotName as SlotName] ?? { enabled: false, placement: "rectangle" }
+  );
+}


### PR DESCRIPTION
## Summary
- カテゴリヒントmeta (`keywords`, `category`) を `<head>` に追加し、広告ターゲティング精度を向上
- `NEXT_PUBLIC_AD_LAYOUT` 環境変数によるA/Bテスト用フィーチャーフラグを追加（`default` / `variant-a` / `variant-b` の3バリエーション）
- 広告パフォーマンス計測用GA4カスタムイベント（`ad_impression`, `ad_click`）を AdBanner に統合

## Changes
| File | What |
|---|---|
| `layout.tsx` | `<head>` にカテゴリヒントmeta追加 |
| `ad-layout.ts` | A/Bテスト用レイアウト設定（新規） |
| `ad-slot.tsx` | レイアウト設定に基づくスロット表示制御 |
| `ad-banner.tsx` | GA4 ad_impression/ad_click イベント追加 |
| `.env.example` | `NEXT_PUBLIC_AD_LAYOUT` 追加 |

## Test plan
- [ ] `NEXT_PUBLIC_AD_LAYOUT=default` でビルド成功（確認済み）
- [ ] `NEXT_PUBLIC_AD_LAYOUT=variant-a` で idle-leaderboard/converting-leaderboard が表示、completed-rectangle が非表示
- [ ] `NEXT_PUBLIC_AD_LAYOUT=variant-b` で idle-leaderboard が非表示、sidebar-rectangle が有効化
- [ ] GA4 debug mode で ad_impression イベントがビューポート進入時に発火
- [ ] GA4 debug mode で ad_click イベントが広告クリック時に発火
- [ ] 高パフォーマンスサイズ（300x250, 728x90）が優先配置されていること
- [ ] First Load JS 102kB（変更前後で差異なし）

Closes #27