### PR TITLE
feat: add share buttons with UTM tracking

### DIFF
--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -8,6 +8,7 @@ import { FormatSelector } from "./format-selector";
 import { ProgressBar } from "./progress-bar";
 import { UpgradeModal } from "./upgrade-modal";
 import { UpgradeBanner } from "./upgrade-banner";
+import { ShareButtons } from "./share-buttons";
 import { AdSlot } from "./ad-slot";
 import { useConversion } from "@/hooks/use-conversion";
 import { useGAEvent } from "@/hooks/use-ga-event";
@@ -197,6 +198,10 @@ export function ConversionCard() {
             {t("downloadFile")}
           </a>
           <p className="text-xs text-muted-foreground">{t("expiresIn", { hours: 24 })}</p>
+
+          {/* Share buttons */}
+          <ShareButtons from={inputFormat} to={convOutputFormat} />
+
           <button
             onClick={handleReset}
             className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"

--- a/apps/web/src/components/share-buttons.tsx
+++ b/apps/web/src/components/share-buttons.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { Copy, Share2 } from "lucide-react";
+import { toast } from "sonner";
+import { buildShareUrl, type ShareSource } from "@/lib/utm";
+import { useGAEvent } from "@/hooks/use-ga-event";
+
+interface ShareButtonsProps {
+  /** Input format (e.g. "heic") */
+  from: string;
+  /** Output format (e.g. "jpg") */
+  to: string;
+  /** Page path for the share URL (default: "/") */
+  path?: string;
+}
+
+/** X (Twitter) icon — inline SVG to avoid extra dependency */
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+/** Facebook icon */
+function FacebookIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" />
+    </svg>
+  );
+}
+
+/** LINE icon */
+function LineIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.48 2 2 5.82 2 10.5c0 4.21 3.74 7.74 8.79 8.4.34.07.81.23.93.52.1.27.07.68.03.95l-.15.9c-.05.27-.21 1.07.94.58 1.14-.49 6.17-3.63 8.42-6.22C22.86 13.47 22 11.82 22 10.5 22 5.82 17.52 2 12 2zm-3.44 11.19h-2.3a.47.47 0 01-.47-.47V8.53a.47.47 0 01.94 0v3.72h1.83a.47.47 0 010 .94zm1.54-.47a.47.47 0 01-.94 0V8.53a.47.47 0 01.94 0v4.19zm4.14 0a.47.47 0 01-.38.46.47.47 0 01-.5-.23l-2.1-2.86v2.63a.47.47 0 01-.93 0V8.53a.47.47 0 01.38-.46.47.47 0 01.5.22l2.1 2.87V8.53a.47.47 0 01.93 0v4.19zm3.14-3.25a.47.47 0 010 .94H15.9v.93h1.48a.47.47 0 010 .94H15.9v.93h1.48a.47.47 0 010 .94h-1.95a.47.47 0 01-.47-.47V8.53a.47.47 0 01.47-.47h1.95a.47.47 0 010 .94H15.9v.93h1.48z" />
+    </svg>
+  );
+}
+
+export function ShareButtons({ from, to, path = "/" }: ShareButtonsProps) {
+  const t = useTranslations("share");
+  const { trackShare } = useGAEvent();
+
+  const shareText = t("shareText", { from: from.toUpperCase(), to: to.toUpperCase() });
+
+  const openShareWindow = useCallback(
+    (url: string, source: ShareSource) => {
+      trackShare(source, from, to);
+      window.open(url, "_blank", "noopener,noreferrer,width=600,height=400");
+    },
+    [trackShare, from, to],
+  );
+
+  const handleTwitter = useCallback(() => {
+    const shareUrl = buildShareUrl(path, "twitter");
+    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`;
+    openShareWindow(url, "twitter");
+  }, [path, shareText, openShareWindow]);
+
+  const handleFacebook = useCallback(() => {
+    const shareUrl = buildShareUrl(path, "facebook");
+    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
+    openShareWindow(url, "facebook");
+  }, [path, openShareWindow]);
+
+  const handleLine = useCallback(() => {
+    const shareUrl = buildShareUrl(path, "line");
+    const url = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(shareText)}`;
+    openShareWindow(url, "line");
+  }, [path, shareText, openShareWindow]);
+
+  const handleCopyLink = useCallback(async () => {
+    const shareUrl = buildShareUrl(path, "copy_link");
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success(t("linkCopied"));
+      trackShare("copy_link", from, to);
+    } catch {
+      // Fallback for older browsers
+      const textArea = document.createElement("textarea");
+      textArea.value = shareUrl;
+      textArea.style.position = "fixed";
+      textArea.style.opacity = "0";
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+      toast.success(t("linkCopied"));
+      trackShare("copy_link", from, to);
+    }
+  }, [path, t, trackShare, from, to]);
+
+  const handleNativeShare = useCallback(async () => {
+    const shareUrl = buildShareUrl(path, "native_share");
+    try {
+      await navigator.share({
+        title: "QuickConv",
+        text: shareText,
+        url: shareUrl,
+      });
+      trackShare("native_share", from, to);
+    } catch (err) {
+      // User cancelled or API error — ignore AbortError
+      if ((err as DOMException).name !== "AbortError") {
+        // Fallback to copy
+        await handleCopyLink();
+      }
+    }
+  }, [path, shareText, trackShare, from, to, handleCopyLink]);
+
+  const supportsNativeShare = typeof navigator !== "undefined" && !!navigator.share;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground text-center">{t("shareResult")}</p>
+      <div className="flex items-center justify-center gap-2">
+        {/* X (Twitter) */}
+        <button
+          type="button"
+          onClick={handleTwitter}
+          className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+          aria-label={t("shareOnX")}
+        >
+          <XIcon className="h-4 w-4" />
+        </button>
+
+        {/* Facebook */}
+        <button
+          type="button"
+          onClick={handleFacebook}
+          className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+          aria-label={t("shareOnFacebook")}
+        >
+          <FacebookIcon className="h-4 w-4" />
+        </button>
+
+        {/* LINE */}
+        <button
+          type="button"
+          onClick={handleLine}
+          className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+          aria-label={t("shareOnLine")}
+        >
+          <LineIcon className="h-4 w-4" />
+        </button>
+
+        {/* Copy Link */}
+        <button
+          type="button"
+          onClick={handleCopyLink}
+          className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+          aria-label={t("copyLink")}
+        >
+          <Copy className="h-4 w-4" />
+        </button>
+
+        {/* Native Share (mobile) */}
+        {supportsNativeShare && (
+          <button
+            type="button"
+            onClick={handleNativeShare}
+            className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+            aria-label={t("nativeShare")}
+          >
+            <Share2 className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-ga-event.ts
+++ b/apps/web/src/hooks/use-ga-event.ts
@@ -61,11 +61,24 @@ export function useGAEvent() {
     []
   );
 
+  const trackShare = useCallback(
+    (method: string, from: string, to: string) => {
+      sendEvent("share", {
+        method,
+        content_type: "conversion_result",
+        from,
+        to,
+      });
+    },
+    []
+  );
+
   return {
     trackFileUpload,
     trackConversionStart,
     trackConversionComplete,
     trackConversionError,
     trackFileDownload,
+    trackShare,
   };
 }

--- a/apps/web/src/lib/utm.ts
+++ b/apps/web/src/lib/utm.ts
@@ -1,0 +1,49 @@
+/**
+ * UTM Parameter Builder for QuickConv share links
+ *
+ * UTM Taxonomy:
+ * -------------------------------------------------------
+ * | Parameter      | Value                | Description              |
+ * |----------------|----------------------|--------------------------|
+ * | utm_source     | twitter / facebook / | Which SNS or "copy_link" |
+ * |                | line / copy_link /   |                          |
+ * |                | native_share         |                          |
+ * | utm_medium     | social               | Always "social" for shares|
+ * | utm_campaign   | conversion_complete  | Share from result screen  |
+ * -------------------------------------------------------
+ *
+ * Example output:
+ *   https://quickconv.io/?utm_source=twitter&utm_medium=social&utm_campaign=conversion_complete
+ */
+
+const SITE_URL = "https://quickconv.io";
+
+export type ShareSource =
+  | "twitter"
+  | "facebook"
+  | "line"
+  | "copy_link"
+  | "native_share";
+
+/**
+ * Build a share URL with UTM parameters.
+ *
+ * @param path      - Page path (e.g. "/" or "/convert/heic-to-jpg")
+ * @param source    - utm_source value (SNS name or "copy_link")
+ * @param medium    - utm_medium value (default: "social")
+ * @param campaign  - utm_campaign value (default: "conversion_complete")
+ * @returns Full URL string with UTM query parameters
+ */
+export function buildShareUrl(
+  path: string,
+  source: ShareSource,
+  medium = "social",
+  campaign = "conversion_complete",
+): string {
+  const base = `${SITE_URL}${path}`;
+  const url = new URL(base);
+  url.searchParams.set("utm_source", source);
+  url.searchParams.set("utm_medium", medium);
+  url.searchParams.set("utm_campaign", campaign);
+  return url.toString();
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -331,6 +331,16 @@
     "bannerTitle": "You've used all free conversions today",
     "bannerDescription": "Get unlimited conversions with Plus for just ¥380/mo."
   },
+  "share": {
+    "shareResult": "Share your conversion result",
+    "shareText": "Converted {from} to {to} with QuickConv!",
+    "shareOnX": "Share on X",
+    "shareOnFacebook": "Share on Facebook",
+    "shareOnLine": "Share on LINE",
+    "copyLink": "Copy link",
+    "nativeShare": "Share",
+    "linkCopied": "Link copied to clipboard!"
+  },
   "jsonLd": {
     "webAppName": "QuickConv - Free Online Image Converter",
     "webAppDescription": "Convert images between HEIC, WebP, AVIF, PNG, and JPG formats instantly. Free, fast, and secure.",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -146,6 +146,16 @@
     "bannerTitle": "本日の無料変換をすべて使いました",
     "bannerDescription": "Plusなら月¥380で無制限に変換できます。"
   },
+  "share": {
+    "shareResult": "変換結果をシェア",
+    "shareText": "QuickConvで{from}を{to}に変換しました！",
+    "shareOnX": "Xでシェア",
+    "shareOnFacebook": "Facebookでシェア",
+    "shareOnLine": "LINEでシェア",
+    "copyLink": "リンクをコピー",
+    "nativeShare": "シェア",
+    "linkCopied": "リンクをコピーしました！"
+  },
   "guideList": {
     "title": "画像変換ガイド",
     "description": "次世代画像フォーマットについて学び、効率的に変換する方法を紹介します。"


### PR DESCRIPTION
## Summary
- **E5-1 (#51)**: OGP share URL with UTM parameters via `buildShareUrl()` utility
- **E5-2 (#52)**: Share buttons (X, Facebook, LINE, copy link, Web Share API) on conversion complete screen
- **E5-3 (#53)**: UTM parameter taxonomy documented in code (`utm_source` per SNS, `utm_medium=social`, `utm_campaign=conversion_complete`)

Additionally:
- GA4 `share` event tracking via `trackShare()` in `use-ga-event.ts`
- i18n support for share UI (en/ja)
- Mobile-friendly with Web Share API fallback

## Files Changed
| File | Change |
|------|--------|
| `apps/web/src/lib/utm.ts` | New: UTM URL builder with taxonomy docs |
| `apps/web/src/components/share-buttons.tsx` | New: Share buttons component |
| `apps/web/src/hooks/use-ga-event.ts` | Add `trackShare` event |
| `apps/web/src/components/conversion-card.tsx` | Integrate ShareButtons |
| `apps/web/src/messages/en.json` | Share UI strings |
| `apps/web/src/messages/ja.json` | Share UI strings (Japanese) |

## Test plan
- [ ] Complete a conversion and verify share buttons appear
- [ ] Click X button: opens tweet intent with UTM URL and prefilled text
- [ ] Click Facebook button: opens share dialog with UTM URL
- [ ] Click LINE button: opens LINE share with UTM URL and text
- [ ] Click copy link: clipboard contains UTM URL, toast notification appears
- [ ] On mobile: Web Share API button appears and triggers native share sheet
- [ ] Verify GA4 events fire on share clicks (check browser console)
- [ ] Verify UTM parameters follow documented taxonomy
- [ ] Test Japanese locale for correct i18n strings

Closes #51, Closes #52, Closes #53