### PR TITLE
feat(web): UTMパラメータ設計・ヘルパー関数

### DIFF
--- a/apps/web/src/lib/utm.ts
+++ b/apps/web/src/lib/utm.ts
@@ -1,0 +1,67 @@
+const SITE_URL = "https://quickconv.cc";
+
+export type UtmSource =
+  | "twitter"
+  | "facebook"
+  | "line"
+  | "reddit"
+  | "hackernews"
+  | "producthunt"
+  | "zenn"
+  | "qiita"
+  | "note"
+  | "direct"
+  | "email";
+
+export type UtmMedium = "social" | "referral" | "email" | "organic";
+
+export type UtmCampaign =
+  | "share"
+  | "launch"
+  | "guide"
+  | "blog"
+  | "newsletter";
+
+interface UtmParams {
+  source: UtmSource;
+  medium: UtmMedium;
+  campaign: UtmCampaign;
+  content?: string;
+}
+
+/**
+ * Build a URL with UTM parameters.
+ * @param path - Page path (e.g., "/convert/jpg-to-avif")
+ * @param utm - UTM parameter object
+ * @returns Full URL with UTM parameters
+ */
+export function buildUtmUrl(path: string, utm: UtmParams): string {
+  const url = new URL(path, SITE_URL);
+  url.searchParams.set("utm_source", utm.source);
+  url.searchParams.set("utm_medium", utm.medium);
+  url.searchParams.set("utm_campaign", utm.campaign);
+  if (utm.content) {
+    url.searchParams.set("utm_content", utm.content);
+  }
+  return url.toString();
+}
+
+/**
+ * Build a share URL for social media.
+ * @param fromFormat - Source format (e.g., "jpg")
+ * @param toFormat - Target format (e.g., "avif")
+ * @param source - Social platform
+ */
+export function buildShareUtmUrl(
+  fromFormat: string,
+  toFormat: string,
+  source: UtmSource
+): string {
+  const slug = `${fromFormat.toLowerCase()}-to-${toFormat.toLowerCase()}`;
+  return buildUtmUrl(`/convert/${slug}`, {
+    source,
+    medium: "social",
+    campaign: "share",
+    content: slug,
+  });
+}

--- a/docs/utm-design.md
+++ b/docs/utm-design.md
@@ -1,0 +1,33 @@
+# UTM パラメータ設計
+
+## 体系
+
+| パラメータ | 値 | 説明 |
+|---|---|---|
+| `utm_source` | twitter, facebook, line, reddit, hackernews, producthunt, zenn, qiita, note, direct, email | 流入元 |
+| `utm_medium` | social, referral, email, organic | チャネル種別 |
+| `utm_campaign` | share, launch, guide, blog, newsletter | キャンペーン |
+| `utm_content` | (任意) | 識別子（変換スラッグ等） |
+
+## チャネル別設定
+
+| チャネル | source | medium | campaign | 用途 |
+|---|---|---|---|---|
+| X シェアボタン | twitter | social | share | ユーザーによるシェア |
+| Facebook シェア | facebook | social | share | ユーザーによるシェア |
+| LINE シェア | line | social | share | ユーザーによるシェア |
+| Reddit 投稿 | reddit | social | launch | r/webdev, r/SideProject |
+| Hacker News | hackernews | social | launch | Show HN |
+| Product Hunt | producthunt | referral | launch | PH ローンチ |
+| Zenn 記事 | zenn | referral | guide | 技術記事 |
+| Qiita 記事 | qiita | referral | guide | 技術記事 |
+| note 記事 | note | referral | blog | ブログ記事 |
+| コピーリンク | direct | social | share | クリップボードコピー |
+
+## ヘルパー関数
+
+`apps/web/src/lib/utm.ts` で `buildUtmUrl()` と `buildShareUtmUrl()` を提供。
+
+## GA4 での確認
+
+「トラフィック獲得」レポートで `utm_source` / `utm_medium` の組み合わせで分類される。


### PR DESCRIPTION
## Summary
- UTM パラメータ体系の設計・文書化（docs/utm-design.md）
- 型付き UTM ヘルパー関数（buildUtmUrl, buildShareUtmUrl）
- 全チャネル（SNS シェア、Reddit/HN/PH ローンチ、技術記事、ブログ）対応

## Test plan
- [ ] buildUtmUrl が正しい URL を生成する
- [ ] buildShareUtmUrl が変換スラッグ付き URL を生成する
- [ ] docs/utm-design.md が存在する

Closes #53
Part of #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)