### PR TITLE
feat(shared): 品質パラメータ型定義・バリデーション

### DIFF
--- a/packages/shared/src/constants/quality.ts
+++ b/packages/shared/src/constants/quality.ts
@@ -1,0 +1,26 @@
+import type { QualityRange, QualityPreset, PlanPreviewLimits } from "../types/quality";
+
+/** Format-specific quality parameter ranges */
+export const QUALITY_RANGES: Record<string, QualityRange> = {
+  jpg: { min: 1, max: 100, default: 80 },
+  jpeg: { min: 1, max: 100, default: 80 },
+  webp: { min: 1, max: 100, default: 80 },
+  avif: { min: 1, max: 63, default: 30, inverted: true },
+  png: { min: 0, max: 9, default: 6, inverted: true },
+};
+
+/** Preset quality values per format (mapped to format-specific ranges) */
+export const QUALITY_PRESETS: Record<string, Record<QualityPreset, number>> = {
+  jpg: { low: 40, medium: 70, high: 95 },
+  jpeg: { low: 40, medium: 70, high: 95 },
+  webp: { low: 40, medium: 75, high: 95 },
+  avif: { low: 50, medium: 30, high: 15 },
+  png: { low: 9, medium: 6, high: 1 },
+};
+
+/** Plan-based preview pattern limits */
+export const PLAN_PREVIEW_LIMITS: PlanPreviewLimits = {
+  free: 2,
+  plus: 5,
+  pro: Infinity,
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,5 +3,8 @@ export * from "./types/api";
 export * from "./types/rate-limit";
 export * from "./constants/formats";
 export * from "./constants/limits";
+export * from "./types/quality";
+export * from "./constants/quality";
 export * from "./validators/file";
+export * from "./validators/quality";
 export * from "./utils/related-conversions";

--- a/packages/shared/src/types/quality.ts
+++ b/packages/shared/src/types/quality.ts
@@ -1,0 +1,34 @@
+/** Quality preset levels */
+export type QualityPreset = "low" | "medium" | "high";
+
+/** Format-specific quality parameter ranges */
+export interface QualityRange {
+  min: number;
+  max: number;
+  default: number;
+  /** Lower value = better quality for some formats (AVIF, PNG) */
+  inverted?: boolean;
+}
+
+/** Quality parameters for a specific conversion */
+export interface QualityParams {
+  preset: QualityPreset;
+  /** Raw quality value (format-specific range) */
+  value: number;
+}
+
+/** A comparison pattern: one quality setting with its result */
+export interface ComparePattern {
+  preset: QualityPreset;
+  quality: number;
+  fileSize: number;
+  /** Base64 or URL of the preview thumbnail */
+  thumbnailUrl: string;
+}
+
+/** Plan-based preview pattern limits */
+export interface PlanPreviewLimits {
+  free: number;
+  plus: number;
+  pro: number;
+}

--- a/packages/shared/src/validators/quality.ts
+++ b/packages/shared/src/validators/quality.ts
@@ -1,0 +1,29 @@
+import { QUALITY_RANGES } from "../constants/quality";
+
+/**
+ * Validate a quality value for a given format.
+ * Returns the clamped value if out of range.
+ */
+export function validateQuality(format: string, value: number): { valid: boolean; value: number } {
+  const range = QUALITY_RANGES[format.toLowerCase()];
+  if (!range) {
+    return { valid: false, value: 0 };
+  }
+
+  if (!Number.isInteger(value)) {
+    return { valid: false, value: range.default };
+  }
+
+  if (value < range.min || value > range.max) {
+    return { valid: false, value: Math.max(range.min, Math.min(range.max, value)) };
+  }
+
+  return { valid: true, value };
+}
+
+/**
+ * Check if a format supports quality adjustment.
+ */
+export function supportsQuality(format: string): boolean {
+  return format.toLowerCase() in QUALITY_RANGES;
+}


### PR DESCRIPTION
## Summary
- 品質パラメータの型定義（QualityPreset, QualityParams, ComparePattern, PlanPreviewLimits）
- フォーマット別品質レンジ（JPEG:1-100, WebP:1-100, AVIF:1-63, PNG:0-9）
- プリセット定義（low/medium/high）
- プラン別プレビューパターン上限（Free:2, Plus:5, Pro:unlimited）
- バリデーション関数（validateQuality, supportsQuality）

## Test plan
- [ ] shared パッケージがビルドエラーなし
- [ ] validateQuality が範囲外の値をクランプする
- [ ] supportsQuality がフォーマット判定できる

Closes #60
Part of #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)