### PR TITLE
feat(converter): add /convert/preview endpoint

### DIFF
--- a/apps/converter/src/routes/convert.ts
+++ b/apps/converter/src/routes/convert.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
-import { convertImage } from "../services/image";
+import { convertImage, generatePreviews } from "../services/image";
 import { downloadFromR2, uploadToR2 } from "../services/r2-client";
+import type { ImageFormat } from "@quickconv/shared";
 
 const convertRoute = new Hono();
 
@@ -92,6 +93,66 @@ convertRoute.post("/direct", async (c) => {
         "X-Job-Id": jobId || "",
       },
     });
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 500);
+  }
+});
+
+// Preview: generate multiple quality variants for comparison
+convertRoute.post("/preview", async (c) => {
+  const apiKey = c.req.header("Authorization")?.replace("Bearer ", "");
+  if (apiKey !== process.env.API_KEY) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const body = await c.req.parseBody();
+  const file = body["file"];
+  const outputFormat = body["outputFormat"] as string;
+  const qualitiesRaw = body["qualities"] as string;
+
+  if (!file || !(file instanceof File)) {
+    return c.json({ error: "No file provided" }, 400);
+  }
+
+  if (!outputFormat) {
+    return c.json({ error: "outputFormat is required" }, 400);
+  }
+
+  if (!qualitiesRaw) {
+    return c.json({ error: "qualities is required" }, 400);
+  }
+
+  let qualities: number[];
+  try {
+    qualities = JSON.parse(qualitiesRaw);
+    if (!Array.isArray(qualities) || qualities.length === 0) {
+      throw new Error("qualities must be a non-empty array");
+    }
+    for (const q of qualities) {
+      if (typeof q !== "number" || q < 1 || q > 100) {
+        throw new Error("Each quality must be a number between 1 and 100");
+      }
+    }
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400);
+  }
+
+  if (qualities.length > 10) {
+    return c.json({ error: "Maximum 10 quality variants allowed" }, 400);
+  }
+
+  try {
+    const inputBuffer = Buffer.from(await file.arrayBuffer());
+    const inputFormat = file.name.split(".").pop() || "";
+
+    const previews = await generatePreviews(
+      inputBuffer,
+      inputFormat,
+      outputFormat as ImageFormat,
+      qualities,
+    );
+
+    return c.json({ previews });
   } catch (error) {
     return c.json({ error: (error as Error).message }, 500);
   }

--- a/apps/converter/src/services/image.ts
+++ b/apps/converter/src/services/image.ts
@@ -1,10 +1,20 @@
 import sharp from "sharp";
 import type { ImageFormat } from "@quickconv/shared";
 
+/** Default quality per format (used when no quality is specified) */
+const DEFAULT_QUALITY: Record<string, number> = {
+  jpg: 85,
+  jpeg: 85,
+  webp: 80,
+  avif: 65,
+};
+
 interface ConvertOptions {
   inputBuffer: Buffer;
   inputFormat: string;
   outputFormat: ImageFormat;
+  quality?: number;
+  maxDimension?: number;
 }
 
 interface ConvertResult {
@@ -13,24 +23,42 @@ interface ConvertResult {
   format: string;
 }
 
+export interface PreviewResult {
+  quality: number;
+  size: number;
+  compressionRatio: number;
+  data: string;
+}
+
 export async function convertImage(options: ConvertOptions): Promise<ConvertResult> {
-  const { inputBuffer, outputFormat } = options;
+  const { inputBuffer, outputFormat, quality, maxDimension } = options;
 
   let pipeline = sharp(inputBuffer);
+
+  if (maxDimension) {
+    pipeline = pipeline.resize({
+      width: maxDimension,
+      height: maxDimension,
+      fit: "inside",
+      withoutEnlargement: true,
+    });
+  }
+
+  const q = quality ?? DEFAULT_QUALITY[outputFormat];
 
   switch (outputFormat) {
     case "jpg":
     case "jpeg":
-      pipeline = pipeline.jpeg({ quality: 85, mozjpeg: true });
+      pipeline = pipeline.jpeg({ quality: q ?? 85, mozjpeg: true });
       break;
     case "png":
       pipeline = pipeline.png({ compressionLevel: 9 });
       break;
     case "webp":
-      pipeline = pipeline.webp({ quality: 80 });
+      pipeline = pipeline.webp({ quality: q ?? 80 });
       break;
     case "avif":
-      pipeline = pipeline.avif({ quality: 65 });
+      pipeline = pipeline.avif({ quality: q ?? 65 });
       break;
     default:
       throw new Error(`Unsupported output format: ${outputFormat}`);
@@ -43,4 +71,36 @@ export async function convertImage(options: ConvertOptions): Promise<ConvertResu
     size: outputBuffer.length,
     format: outputFormat,
   };
+}
+
+const PREVIEW_MAX_DIMENSION = 800;
+
+export async function generatePreviews(
+  inputBuffer: Buffer,
+  inputFormat: string,
+  outputFormat: ImageFormat,
+  qualities: number[],
+): Promise<PreviewResult[]> {
+  const originalSize = inputBuffer.length;
+
+  const results = await Promise.all(
+    qualities.map(async (quality) => {
+      const result = await convertImage({
+        inputBuffer,
+        inputFormat,
+        outputFormat,
+        quality,
+        maxDimension: PREVIEW_MAX_DIMENSION,
+      });
+
+      return {
+        quality,
+        size: result.size,
+        compressionRatio: parseFloat((1 - result.size / originalSize).toFixed(4)),
+        data: result.buffer.toString("base64"),
+      };
+    }),
+  );
+
+  return results;
 }


### PR DESCRIPTION
## Summary
- Add `POST /convert/preview` endpoint to the Converter service that accepts an image file + output format + quality array, and returns multiple quality variants as base64-encoded thumbnails
- Extend `convertImage` in `image.ts` with `quality` and `maxDimension` options (backward-compatible, existing callers unaffected)
- Add `generatePreviews` function that runs Sharp conversions in parallel via `Promise.all`, resizing to max 800px for preview use

## Details
- **Request**: multipart/form-data with `file`, `outputFormat`, `qualities` (JSON array of numbers 1-100)
- **Response**: `{ previews: [{ quality, size, compressionRatio, data }] }`
- Input validation: file required, outputFormat required, qualities must be non-empty array of 1-100, max 10 variants
- No R2 storage -- base64 returned directly for client-side comparison
- Default quality presets extracted to `DEFAULT_QUALITY` map for format-specific defaults

## Test plan
- [ ] Build passes: `npx turbo build --filter=@quickconv/converter`
- [ ] POST /convert/preview with valid image + qualities returns previews array
- [ ] Each preview entry contains quality, size, compressionRatio, data (base64)
- [ ] Missing file / outputFormat / qualities returns 400
- [ ] Invalid qualities (non-array, out of range, > 10 items) returns 400
- [ ] Unauthorized request returns 401
- [ ] Existing /convert and /convert/direct endpoints unaffected

Closes #61