### PR TITLE
feat: quality preview UI & ConversionCard integration

### DIFF
--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -2,7 +2,14 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { Download, RefreshCw, AlertCircle, Loader2 } from "lucide-react";
+import {
+  Download,
+  RefreshCw,
+  AlertCircle,
+  Loader2,
+  ArrowLeft,
+  Eye,
+} from "lucide-react";
 import { FileDropzone } from "./file-dropzone";
 import { FormatSelector } from "./format-selector";
 import { ProgressBar } from "./progress-bar";
@@ -10,8 +17,12 @@ import { UpgradeModal } from "./upgrade-modal";
 import { UpgradeBanner } from "./upgrade-banner";
 import { ShareButtons } from "./share-buttons";
 import { AdSlot } from "./ad-slot";
+import { QualityPatternGrid } from "./quality-pattern-grid";
+import { ImageCompareSlider } from "./image-compare-slider";
 import { useConversion } from "@/hooks/use-conversion";
+import { useSubscription } from "@/hooks/use-subscription";
 import { useGAEvent } from "@/hooks/use-ga-event";
+import { FREE_PREVIEW_LIMIT } from "@quickconv/shared";
 import type { ImageFormat } from "@quickconv/shared";
 
 /** Warning threshold: show warning when remaining <= this value */
@@ -19,20 +30,29 @@ const REMAINING_WARNING_THRESHOLD = 3;
 
 export function ConversionCard() {
   const t = useTranslations("common");
+  const tp = useTranslations("preview");
   const [file, setFile] = useState<File | null>(null);
   const [outputFormat, setOutputFormat] = useState<ImageFormat | null>(null);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
+  const { plan, isPaid } = useSubscription();
   const {
     step,
     uploadProgress,
     downloadUrl,
     error,
     startConversion,
+    startPreview,
+    selectPreviewPattern,
+    cancelPreview,
+    convertWithSelectedQuality,
     reset,
     inputFormat,
     outputFormat: convOutputFormat,
     remainingConversions,
     dailyLimit,
+    previews,
+    selectedPreviewIndex,
+    originalSize,
   } = useConversion();
   const { trackFileDownload } = useGAEvent();
 
@@ -42,6 +62,8 @@ export function ConversionCard() {
     remainingConversions > 0 &&
     remainingConversions <= REMAINING_WARNING_THRESHOLD;
   const hasRateLimitInfo = remainingConversions !== null && dailyLimit !== null;
+
+  const accessibleCount = isPaid ? Infinity : FREE_PREVIEW_LIMIT;
 
   const handleFileSelect = (selectedFile: File) => {
     setFile(selectedFile);
@@ -58,11 +80,31 @@ export function ConversionCard() {
     startConversion(file, outputFormat);
   };
 
+  const handleCompareQuality = () => {
+    if (!file || !outputFormat) return;
+    startPreview(file, outputFormat, plan);
+  };
+
+  const handleConvertWithQuality = () => {
+    if (isRateLimited) {
+      setShowUpgradeModal(true);
+      return;
+    }
+    convertWithSelectedQuality();
+  };
+
+  const handleBackFromPreview = () => {
+    cancelPreview();
+  };
+
   const handleReset = () => {
     setFile(null);
     setOutputFormat(null);
     reset();
   };
+
+  // Selected preview item for the slider
+  const selectedPreview = previews[selectedPreviewIndex];
 
   return (
     <div className="w-full max-w-2xl mx-auto space-y-6">
@@ -125,17 +167,103 @@ export function ConversionCard() {
           />
 
           {file && outputFormat && (
-            <button
-              onClick={handleConvert}
-              className="w-full py-3 rounded-lg font-medium transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
-            >
-              {t("startConversion")}
-            </button>
+            <div className="flex flex-col gap-2">
+              <button
+                onClick={handleConvert}
+                className="w-full py-3 rounded-lg font-medium transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
+              >
+                {t("startConversion")}
+              </button>
+
+              {/* Compare Quality button */}
+              <button
+                onClick={handleCompareQuality}
+                className="w-full py-2.5 rounded-lg font-medium transition-colors border border-border text-foreground hover:bg-muted flex items-center justify-center gap-2"
+              >
+                <Eye className="h-4 w-4" />
+                {tp("compareQuality")}
+              </button>
+
+              {/* Teaser for free users */}
+              {!isPaid && (
+                <p className="text-xs text-muted-foreground text-center">
+                  {tp("freeTeaser")}
+                </p>
+              )}
+            </div>
           )}
 
           {/* Ad: Leaderboard below tool description (idle state) */}
           <AdSlot slot="idle-leaderboard" placement="leaderboard" className="mt-6" />
         </>
+      )}
+
+      {/* Previewing: loading state */}
+      {step === "previewing" && (
+        <div className="rounded-xl border border-border p-8 text-center space-y-4">
+          <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
+          <p className="font-medium">{tp("generatingPreviews")}</p>
+        </div>
+      )}
+
+      {/* Preview Ready: show quality grid + compare slider */}
+      {step === "preview-ready" && previews.length > 0 && (
+        <div className="space-y-6">
+          {/* Back button */}
+          <button
+            onClick={handleBackFromPreview}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            {tp("backToConversion")}
+          </button>
+
+          {/* File info */}
+          {file && (
+            <div className="rounded-lg bg-muted p-3">
+              <p className="text-sm font-medium">{file.name}</p>
+              <p className="text-xs text-muted-foreground">
+                {tp("originalSize")}: {(file.size / 1024).toFixed(1)} KB
+              </p>
+            </div>
+          )}
+
+          {/* Quality Pattern Grid */}
+          <div>
+            <h3 className="text-sm font-medium mb-3">{tp("selectQuality")}</h3>
+            <QualityPatternGrid
+              previews={previews}
+              originalSize={originalSize}
+              selectedIndex={selectedPreviewIndex}
+              onSelect={selectPreviewPattern}
+              isPaid={isPaid}
+              accessibleCount={accessibleCount}
+            />
+          </div>
+
+          {/* Image Compare Slider */}
+          {selectedPreview && file && (
+            <div>
+              <h3 className="text-sm font-medium mb-3">{tp("compareTitle")}</h3>
+              <ImageCompareSlider
+                beforeSrc={URL.createObjectURL(file)}
+                afterSrc={selectedPreview.data}
+                beforeSize={originalSize}
+                afterSize={selectedPreview.size}
+                beforeLabel={tp("original")}
+                afterLabel={tp("converted")}
+              />
+            </div>
+          )}
+
+          {/* Convert with selected quality button */}
+          <button
+            onClick={handleConvertWithQuality}
+            className="w-full py-3 rounded-lg font-medium transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
+          >
+            {tp("convertWithQuality")}
+          </button>
+        </div>
       )}
 
       {/* Step 2: Uploading */}

--- a/apps/web/src/components/quality-pattern-grid.tsx
+++ b/apps/web/src/components/quality-pattern-grid.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Lock, Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { PreviewItem } from "@/lib/api-client";
+
+/** Index of the recommended pattern (medium quality is generally best balance) */
+const RECOMMENDED_INDEX = 1;
+
+interface QualityPatternGridProps {
+  /** Preview items from the API */
+  previews: PreviewItem[];
+  /** Original file size in bytes */
+  originalSize: number;
+  /** Currently selected index */
+  selectedIndex: number;
+  /** Callback when a pattern is clicked */
+  onSelect: (index: number) => void;
+  /** Whether the user is on a paid plan */
+  isPaid: boolean;
+  /** Max patterns accessible to the user (from PLAN_PREVIEW_LIMITS) */
+  accessibleCount: number;
+  className?: string;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+const PRESET_LABELS: Record<number, string> = {
+  0: "low",
+  1: "medium",
+  2: "high",
+  3: "lossless",
+};
+
+export function QualityPatternGrid({
+  previews,
+  originalSize,
+  selectedIndex,
+  onSelect,
+  isPaid,
+  accessibleCount,
+  className,
+}: QualityPatternGridProps) {
+  const t = useTranslations("preview");
+
+  return (
+    <div className={cn("grid grid-cols-2 sm:grid-cols-4 gap-3", className)}>
+      {previews.map((item, index) => {
+        const isLocked = !isPaid && index >= accessibleCount;
+        const isSelected = index === selectedIndex;
+        const isRecommended = index === RECOMMENDED_INDEX;
+        const reduction =
+          originalSize > 0
+            ? Math.round(((originalSize - item.size) / originalSize) * 100)
+            : 0;
+        const presetKey = PRESET_LABELS[index] || `q${item.quality}`;
+
+        return (
+          <button
+            key={item.quality}
+            type="button"
+            onClick={() => {
+              if (!isLocked) {
+                onSelect(index);
+              }
+            }}
+            disabled={isLocked}
+            className={cn(
+              "relative flex flex-col items-center rounded-lg border p-2 transition-all",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              isSelected && !isLocked
+                ? "border-primary ring-2 ring-primary/30 bg-primary/5"
+                : "border-border hover:border-muted-foreground/50",
+              isLocked && "cursor-not-allowed opacity-60",
+            )}
+            aria-label={
+              isLocked
+                ? t("lockedPattern", { preset: t(presetKey) })
+                : t("selectPattern", { preset: t(presetKey) })
+            }
+          >
+            {/* Recommended badge */}
+            {isRecommended && (
+              <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 inline-flex items-center gap-0.5 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-900/40 dark:text-amber-200 whitespace-nowrap">
+                <Star className="h-3 w-3" />
+                {t("recommended")}
+              </span>
+            )}
+
+            {/* Thumbnail */}
+            <div className="relative w-full aspect-square rounded overflow-hidden bg-muted mt-1">
+              {isLocked ? (
+                <>
+                  {/* Blurred thumbnail for locked patterns */}
+                  <img
+                    src={item.data}
+                    alt=""
+                    className="w-full h-full object-cover blur-sm scale-105"
+                    draggable={false}
+                  />
+                  {/* Lock overlay */}
+                  <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 backdrop-blur-[1px]">
+                    <Lock className="h-5 w-5 text-white mb-1" />
+                    <span className="text-[10px] text-white font-medium text-center px-1">
+                      {t("upgradePlus")}
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <img
+                  src={item.data}
+                  alt={t("previewAlt", { preset: t(presetKey) })}
+                  className="w-full h-full object-cover"
+                  draggable={false}
+                />
+              )}
+            </div>
+
+            {/* Label */}
+            <span className="mt-1.5 text-xs font-medium capitalize">
+              {t(presetKey)}
+            </span>
+
+            {/* Size & compression ratio */}
+            <span className="text-[11px] text-muted-foreground">
+              {formatSize(item.size)}
+            </span>
+            <span
+              className={cn(
+                "text-[11px] font-semibold",
+                reduction > 0
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-muted-foreground",
+              )}
+            >
+              {reduction > 0 ? `-${reduction}%` : `+${Math.abs(reduction)}%`}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-conversion.ts
+++ b/apps/web/src/hooks/use-conversion.ts
@@ -1,13 +1,26 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
-import { uploadFile, requestConversion, checkStatus, getDownloadUrl } from "@/lib/api-client";
-import type { RateLimitInfo } from "@/lib/api-client";
+import {
+  uploadFile,
+  requestConversion,
+  requestPreview,
+  checkStatus,
+  getDownloadUrl,
+} from "@/lib/api-client";
+import type { RateLimitInfo, PreviewItem } from "@/lib/api-client";
 import { POLLING_INTERVAL_MS } from "@quickconv/shared";
 import type { ImageFormat } from "@quickconv/shared";
 import { useGAEvent } from "./use-ga-event";
 
-type Step = "idle" | "uploading" | "converting" | "completed" | "failed";
+type Step =
+  | "idle"
+  | "uploading"
+  | "converting"
+  | "completed"
+  | "failed"
+  | "previewing"
+  | "preview-ready";
 
 interface ConversionState {
   step: Step;
@@ -15,6 +28,12 @@ interface ConversionState {
   jobId: string | null;
   downloadUrl: string | null;
   error: string | null;
+}
+
+interface PreviewState {
+  previews: PreviewItem[];
+  selectedIndex: number;
+  originalSize: number;
 }
 
 export function useConversion() {
@@ -25,12 +44,26 @@ export function useConversion() {
     downloadUrl: null,
     error: null,
   });
+  const [previewState, setPreviewState] = useState<PreviewState>({
+    previews: [],
+    selectedIndex: 0,
+    originalSize: 0,
+  });
   const [remainingConversions, setRemainingConversions] = useState<number | null>(null);
   const [dailyLimit, setDailyLimit] = useState<number | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const startTimeRef = useRef<number>(0);
   const formatsRef = useRef<{ from: string; to: string }>({ from: "", to: "" });
-  const { trackFileUpload, trackConversionStart, trackConversionComplete, trackConversionError } = useGAEvent();
+  const fileRef = useRef<File | null>(null);
+  const outputFormatRef = useRef<ImageFormat | null>(null);
+  const {
+    trackFileUpload,
+    trackConversionStart,
+    trackConversionComplete,
+    trackConversionError,
+    trackPreviewStart,
+    trackPreviewSelectQuality,
+  } = useGAEvent();
 
   const handleRateLimitUpdate = useCallback((info: RateLimitInfo) => {
     setRemainingConversions(info.remaining);
@@ -42,6 +75,76 @@ export function useConversion() {
       clearInterval(pollingRef.current);
       pollingRef.current = null;
     }
+  }, []);
+
+  /** Start preview: fetch quality pattern previews from the API */
+  const startPreview = useCallback(
+    async (file: File, outputFormat: ImageFormat, plan: string) => {
+      setState({
+        step: "previewing",
+        uploadProgress: 0,
+        jobId: null,
+        downloadUrl: null,
+        error: null,
+      });
+
+      const inputFormat = file.name.split(".").pop()?.toLowerCase() || "unknown";
+      formatsRef.current = { from: inputFormat, to: outputFormat };
+      fileRef.current = file;
+      outputFormatRef.current = outputFormat;
+
+      trackPreviewStart(inputFormat, outputFormat);
+
+      try {
+        // Default quality values for low, medium, high, lossless
+        const qualities = [30, 70, 95, 100];
+
+        const result = await requestPreview(file, outputFormat, qualities, plan);
+
+        setPreviewState({
+          previews: result.previews,
+          selectedIndex: 1, // default to medium (recommended)
+          originalSize: file.size,
+        });
+
+        setState((s) => ({ ...s, step: "preview-ready" }));
+      } catch (error) {
+        setState((s) => ({
+          ...s,
+          step: "failed",
+          error: (error as Error).message,
+        }));
+      }
+    },
+    [trackPreviewStart],
+  );
+
+  /** Select a quality pattern from the preview grid */
+  const selectPreviewPattern = useCallback(
+    (index: number) => {
+      const inputFormat = formatsRef.current.from;
+      const outputFormat = formatsRef.current.to;
+      const quality = previewState.previews[index]?.quality;
+
+      if (quality !== undefined) {
+        trackPreviewSelectQuality(inputFormat, outputFormat, quality);
+      }
+
+      setPreviewState((s) => ({ ...s, selectedIndex: index }));
+    },
+    [previewState.previews, trackPreviewSelectQuality],
+  );
+
+  /** Exit preview mode and go back to idle */
+  const cancelPreview = useCallback(() => {
+    setState({
+      step: "idle",
+      uploadProgress: 0,
+      jobId: null,
+      downloadUrl: null,
+      error: null,
+    });
+    setPreviewState({ previews: [], selectedIndex: 0, originalSize: 0 });
   }, []);
 
   const startConversion = useCallback(
@@ -119,18 +222,39 @@ export function useConversion() {
     [stopPolling, handleRateLimitUpdate, trackFileUpload, trackConversionStart, trackConversionComplete, trackConversionError]
   );
 
+  /** Convert with the selected quality from preview */
+  const convertWithSelectedQuality = useCallback(() => {
+    const file = fileRef.current;
+    const outputFormat = outputFormatRef.current;
+    if (!file || !outputFormat) return;
+
+    // Clear preview state and start normal conversion
+    setPreviewState({ previews: [], selectedIndex: 0, originalSize: 0 });
+    startConversion(file, outputFormat);
+  }, [startConversion]);
+
   const reset = useCallback(() => {
     stopPolling();
     setState({ step: "idle", uploadProgress: 0, jobId: null, downloadUrl: null, error: null });
+    setPreviewState({ previews: [], selectedIndex: 0, originalSize: 0 });
+    fileRef.current = null;
+    outputFormatRef.current = null;
   }, [stopPolling]);
 
   return {
     ...state,
     startConversion,
+    startPreview,
+    selectPreviewPattern,
+    cancelPreview,
+    convertWithSelectedQuality,
     reset,
     inputFormat: formatsRef.current.from,
     outputFormat: formatsRef.current.to,
     remainingConversions,
     dailyLimit,
+    previews: previewState.previews,
+    selectedPreviewIndex: previewState.selectedIndex,
+    originalSize: previewState.originalSize,
   };
 }

--- a/apps/web/src/hooks/use-ga-event.ts
+++ b/apps/web/src/hooks/use-ga-event.ts
@@ -73,6 +73,20 @@ export function useGAEvent() {
     []
   );
 
+  const trackPreviewStart = useCallback(
+    (from: string, to: string) => {
+      sendEvent("preview_start", { from, to });
+    },
+    []
+  );
+
+  const trackPreviewSelectQuality = useCallback(
+    (from: string, to: string, quality: number) => {
+      sendEvent("preview_select_quality", { from, to, quality });
+    },
+    []
+  );
+
   return {
     trackFileUpload,
     trackConversionStart,
@@ -80,5 +94,7 @@ export function useGAEvent() {
     trackConversionError,
     trackFileDownload,
     trackShare,
+    trackPreviewStart,
+    trackPreviewSelectQuality,
   };
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -101,3 +101,43 @@ export async function checkStatus(jobId: string): Promise<StatusResponse> {
 export function getDownloadUrl(jobId: string): string {
   return `${API_URL}/api/download/${jobId}`;
 }
+
+/** Preview item returned from the preview endpoint */
+export interface PreviewItem {
+  quality: number;
+  size: number;
+  compressionRatio: number;
+  data: string; // base64 data URL
+}
+
+export interface PreviewResponse {
+  previews: PreviewItem[];
+  requestedCount: number;
+  returnedCount: number;
+  plan: string;
+}
+
+export async function requestPreview(
+  file: File,
+  outputFormat: string,
+  qualities: number[],
+  plan: string,
+): Promise<PreviewResponse> {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("outputFormat", outputFormat);
+  formData.append("qualities", JSON.stringify(qualities));
+  formData.append("plan", plan);
+
+  const res = await fetch(`${API_URL}/api/preview`, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || "Preview request failed");
+  }
+
+  return res.json();
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -341,6 +341,27 @@
     "nativeShare": "Share",
     "linkCopied": "Link copied to clipboard!"
   },
+  "preview": {
+    "compareQuality": "Compare Quality",
+    "freeTeaser": "Compare quality presets before converting (2 patterns free)",
+    "generatingPreviews": "Generating quality previews...",
+    "backToConversion": "Back",
+    "originalSize": "Original",
+    "selectQuality": "Select quality preset",
+    "compareTitle": "Side-by-side comparison",
+    "original": "Original",
+    "converted": "Converted",
+    "convertWithQuality": "Convert with this quality",
+    "recommended": "Recommended",
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "lossless": "Lossless",
+    "upgradePlus": "Upgrade to Plus",
+    "selectPattern": "Select {preset} quality",
+    "lockedPattern": "{preset} quality (locked)",
+    "previewAlt": "{preset} quality preview"
+  },
   "jsonLd": {
     "webAppName": "QuickConv - Free Online Image Converter",
     "webAppDescription": "Convert images between HEIC, WebP, AVIF, PNG, and JPG formats instantly. Free, fast, and secure.",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -341,6 +341,27 @@
     "conclusionTitle": "まとめ",
     "conclusionText": "各フォーマットにはそれぞれの役割があります：最大の互換性ならWebP、最高の圧縮率と品質ならAVIF、Appleエコシステム内ならHEIC。2026年のWeb利用では、AVIFをメインにWebPのフォールバックを用意するのが推奨戦略です。QuickConvを使えば、これらすべてのフォーマット間を無料で簡単に変換できます。"
   },
+  "preview": {
+    "compareQuality": "品質を比較",
+    "freeTeaser": "変換前に品質プリセットを比較できます（無料で2パターン）",
+    "generatingPreviews": "プレビューを生成中...",
+    "backToConversion": "戻る",
+    "originalSize": "元のサイズ",
+    "selectQuality": "品質プリセットを選択",
+    "compareTitle": "左右比較",
+    "original": "元画像",
+    "converted": "変換後",
+    "convertWithQuality": "この品質で変換",
+    "recommended": "おすすめ",
+    "low": "低品質",
+    "medium": "中品質",
+    "high": "高品質",
+    "lossless": "ロスレス",
+    "upgradePlus": "Plusにアップグレード",
+    "selectPattern": "{preset}品質を選択",
+    "lockedPattern": "{preset}品質（ロック中）",
+    "previewAlt": "{preset}品質のプレビュー"
+  },
   "jsonLd": {
     "webAppName": "QuickConv - 無料オンライン画像変換",
     "webAppDescription": "HEIC、WebP、AVIF、PNG、JPG形式の画像を瞬時に変換。無料・高速・安全。",


### PR DESCRIPTION
## Summary
- Add `QualityPatternGrid` component: thumbnails with file size/compression ratio, recommended badge, lock+blur for free user limits (E6-6 #65)
- Integrate preview mode into `ConversionCard`: "Compare Quality" button, preview phase, "Convert with this quality" flow (E6-8 #67)
- Add `useConversion` preview phase (`previewing`/`preview-ready`) with `/api/preview` integration
- Add GA4 events: `preview_start`, `preview_select_quality`
- Add i18n messages (en/ja) for all preview UI strings

Closes #65, Closes #67

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Quality pattern thumbnails display in grid (2x4 layout)
- [ ] File size (KB) and compression ratio (e.g. `-67%`) shown under each thumbnail
- [ ] Selected pattern has highlight border
- [ ] Clicking a pattern updates the ImageCompareSlider
- [ ] Free user: 3rd+ patterns show lock+blur overlay with "Upgrade to Plus"
- [ ] "Compare Quality" button appears on ConversionCard after file+format selection
- [ ] Preview mode: back button returns to idle state
- [ ] "Convert with this quality" triggers normal conversion flow
- [ ] GA4 events fire correctly
- [ ] i18n: both EN and JA strings render properly