### PR TITLE
feat(web): add frontend Sentry SDK and error boundaries

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@quickconv/shared": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@sentry/browser": "^10.43.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.474.0",

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -11,6 +11,8 @@ import { CfAnalytics } from "@/components/cf-analytics";
 import { CookieConsent } from "@/components/cookie-consent";
 import { OrganizationJsonLd } from "@/components/json-ld";
 import { AdSlot } from "@/components/ad-slot";
+import { SentryInit } from "@/components/sentry-init";
+import { GlobalErrorBoundary } from "@/components/error-boundary";
 import "../globals.css";
 
 export function generateStaticParams() {
@@ -49,16 +51,19 @@ export default async function LocaleLayout({
         <OrganizationJsonLd />
       </head>
       <body className="min-h-screen flex flex-col bg-background text-foreground">
+        <SentryInit />
         <GoogleAnalytics />
         <CfAnalytics />
         <NextIntlClientProvider messages={messages}>
-          <Header />
-          <main className="flex-1">{children}</main>
-          {/* Ad: Leaderboard above footer */}
-          <div className="max-w-5xl mx-auto px-4 py-4">
-            <AdSlot slot="footer-leaderboard" placement="leaderboard" />
-          </div>
-          <Footer />
+          <GlobalErrorBoundary>
+            <Header />
+            <main className="flex-1">{children}</main>
+            {/* Ad: Leaderboard above footer */}
+            <div className="max-w-5xl mx-auto px-4 py-4">
+              <AdSlot slot="footer-leaderboard" placement="leaderboard" />
+            </div>
+            <Footer />
+          </GlobalErrorBoundary>
           <CookieConsent />
           <Toaster position="top-center" richColors />
         </NextIntlClientProvider>

--- a/apps/web/src/components/error-boundary.tsx
+++ b/apps/web/src/components/error-boundary.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Sentry } from "@/lib/sentry";
+
+/* ---------- props / state ---------- */
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Optional fallback UI. When omitted the default error message is shown. */
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/* ---------- GlobalErrorBoundary ---------- */
+
+/**
+ * Top-level error boundary that catches any unhandled React error,
+ * reports it to Sentry, and shows a friendly recovery message.
+ */
+export class GlobalErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    Sentry.captureException(error, {
+      extra: { componentStack: errorInfo.componentStack },
+    });
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      return (
+        <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+          <h2 className="text-xl font-semibold">
+            Something went wrong
+          </h2>
+          <p className="text-muted-foreground max-w-md">
+            An unexpected error occurred. Please try reloading the page. If the
+            problem persists, contact support.
+          </p>
+          <button
+            type="button"
+            onClick={this.handleReload}
+            className="mt-2 rounded-lg bg-primary px-6 py-2 text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Reload page
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+/* ---------- ConversionErrorBoundary ---------- */
+
+interface ConversionErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Error boundary scoped to the file-conversion flow.
+ *
+ * Unlike the global boundary it offers a "Try again" action that resets
+ * the boundary state so the user can retry without a full page reload.
+ */
+export class ConversionErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ConversionErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ConversionErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    Sentry.captureException(error, {
+      tags: { flow: "conversion" },
+      extra: { componentStack: errorInfo.componentStack },
+    });
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      return (
+        <div className="flex flex-col items-center justify-center gap-4 rounded-xl border border-destructive/30 bg-destructive/5 p-8 text-center">
+          <h3 className="text-lg font-semibold text-destructive">
+            Conversion error
+          </h3>
+          <p className="text-muted-foreground max-w-md">
+            Something went wrong during the conversion. Please try again or
+            select a different file.
+          </p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="mt-2 rounded-lg bg-primary px-6 py-2 text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/src/components/sentry-init.tsx
+++ b/apps/web/src/components/sentry-init.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { initSentry } from "@/lib/sentry";
+
+/**
+ * Client component that initializes Sentry on mount.
+ *
+ * Placed in the layout so that Sentry is ready before any error can occur.
+ * Renders nothing — purely a side-effect component.
+ */
+export function SentryInit() {
+  useEffect(() => {
+    initSentry();
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import * as Sentry from "@sentry/browser";
+import { buildSentryOptions } from "@quickconv/shared";
+
+let initialized = false;
+
+/**
+ * Initialize Sentry for the client-side frontend.
+ *
+ * Uses @sentry/browser because the app uses static export (output: "export")
+ * where @sentry/nextjs server features are unavailable.
+ *
+ * Safe to call multiple times — only the first call takes effect.
+ * When NEXT_PUBLIC_SENTRY_DSN is not set, Sentry disables itself silently.
+ */
+export function initSentry(): void {
+  if (initialized) return;
+  initialized = true;
+
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  const options = buildSentryOptions(dsn, "frontend");
+
+  Sentry.init(options);
+}
+
+export { Sentry };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@sentry/browser':
+        specifier: ^10.43.0
+        version: 10.43.0
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -153,6 +156,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
 
 packages:
 
@@ -1502,6 +1508,26 @@ packages:
 
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
+  '@sentry-internal/browser-utils@10.43.0':
+    resolution: {integrity: sha512-8zYTnzhAPvNkVH1Irs62wl0J/c+0QcJ62TonKnzpSFUUD3V5qz8YDZbjIDGfxy+1EB9fO0sxtddKCzwTHF/MbQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.43.0':
+    resolution: {integrity: sha512-YoXuwluP6eOcQxTeTtaWb090++MrLyWOVsUTejzUQQ6LFL13Jwt+bDPF1kvBugMq4a7OHw/UNKQfd6//rZMn2g==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.43.0':
+    resolution: {integrity: sha512-ZIw1UNKOFXo1LbPCJPMAx9xv7D8TMZQusLDUgb6BsPQJj0igAuwd7KRGTkjjgnrwBp2O/sxcQFRhQhknWk7QPg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.43.0':
+    resolution: {integrity: sha512-khCXlGrlH1IU7P5zCEAJFestMeH97zDVCekj8OsNNDtN/1BmCJ46k6Xi0EqAUzdJgrOLJeLdoYdgtiIjovZ8Sg==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.43.0':
+    resolution: {integrity: sha512-2V3I3sXi3SMeiZpKixd9ztokSgK27cmvsD9J5oyOyjhGLTW/6QKCwHbKnluMgQMXq20nixQk5zN4wRjRUma3sg==}
+    engines: {node: '>=18'}
 
   '@sentry/core@10.43.0':
     resolution: {integrity: sha512-l0SszQAPiQGWl/ferw8GP3ALyHXiGiRKJaOvNmhGO+PrTQyZTZ6OYyPnGijAFRg58dE1V3RCH/zw5d2xSUIiNg==}
@@ -4266,6 +4292,32 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@schummar/icu-type-parser@1.21.5': {}
+
+  '@sentry-internal/browser-utils@10.43.0':
+    dependencies:
+      '@sentry/core': 10.43.0
+
+  '@sentry-internal/feedback@10.43.0':
+    dependencies:
+      '@sentry/core': 10.43.0
+
+  '@sentry-internal/replay-canvas@10.43.0':
+    dependencies:
+      '@sentry-internal/replay': 10.43.0
+      '@sentry/core': 10.43.0
+
+  '@sentry-internal/replay@10.43.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.43.0
+      '@sentry/core': 10.43.0
+
+  '@sentry/browser@10.43.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.43.0
+      '@sentry-internal/feedback': 10.43.0
+      '@sentry-internal/replay': 10.43.0
+      '@sentry-internal/replay-canvas': 10.43.0
+      '@sentry/core': 10.43.0
 
   '@sentry/core@10.43.0': {}
 


### PR DESCRIPTION
## Summary
- Install `@sentry/browser` for client-side error tracking (static export incompatible with `@sentry/nextjs`)
- Add `SentryInit` component and `initSentry()` using shared `buildSentryOptions` from `@quickconv/shared`
- Add `GlobalErrorBoundary` (top-level) and `ConversionErrorBoundary` (conversion flow) with Sentry error reporting
- Integrate into locale layout: Sentry init runs on mount, GlobalErrorBoundary wraps main content

## Test plan
- [ ] Build succeeds with `pnpm --filter @quickconv/web build`
- [ ] TypeScript check passes with `pnpm --filter @quickconv/web lint`
- [ ] No errors when `NEXT_PUBLIC_SENTRY_DSN` is not set (Sentry silently disabled)
- [ ] With DSN set, thrown errors are captured and sent to Sentry
- [ ] GlobalErrorBoundary shows "Something went wrong" message on unhandled error
- [ ] ConversionErrorBoundary shows "Conversion error" with "Try again" button

Closes #73