### PR TITLE
feat: add custom Sentry metrics and alert rules

### DIFF
--- a/apps/api/src/middleware/sentry.ts
+++ b/apps/api/src/middleware/sentry.ts
@@ -22,10 +22,13 @@ export function sentryMiddleware() {
       });
 
       sentry.setTag("service", "quickconv-api");
+      sentry.setTag("endpoint", c.req.path);
 
       await next();
 
       const status = c.res.status;
+      sentry.setTag("rate_limited", String(status === 429));
+
       if (status >= 500) {
         sentry.setExtras({
           url: c.req.url,

--- a/apps/converter/src/lib/sentry.ts
+++ b/apps/converter/src/lib/sentry.ts
@@ -32,6 +32,40 @@ export function captureException(error: unknown, context?: Record<string, unknow
   });
 }
 
+export interface ConversionMetrics {
+  conversionFormat: string;
+  durationMs: number;
+  fileSizeInput: number;
+  fileSizeOutput: number;
+}
+
+export function addConversionBreadcrumb(metrics: ConversionMetrics): void {
+  if (!initialized) return;
+
+  Sentry.addBreadcrumb({
+    category: "conversion",
+    message: `Converted ${metrics.conversionFormat} in ${metrics.durationMs}ms`,
+    level: "info",
+    data: {
+      conversion_format: metrics.conversionFormat,
+      conversion_duration_ms: metrics.durationMs,
+      file_size_input: metrics.fileSizeInput,
+      file_size_output: metrics.fileSizeOutput,
+    },
+  });
+
+  Sentry.withScope((scope) => {
+    scope.setTags({
+      conversion_format: metrics.conversionFormat,
+    });
+    scope.setExtras({
+      conversion_duration_ms: metrics.durationMs,
+      file_size_input: metrics.fileSizeInput,
+      file_size_output: metrics.fileSizeOutput,
+    });
+  });
+}
+
 export function checkMemoryUsage(): void {
   if (!initialized) return;
 

--- a/apps/converter/src/routes/convert.ts
+++ b/apps/converter/src/routes/convert.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { convertImage, generatePreviews } from "../services/image";
 import { downloadFromR2, uploadToR2 } from "../services/r2-client";
-import { captureException, checkMemoryUsage } from "../lib/sentry";
+import { addConversionBreadcrumb, captureException, checkMemoryUsage } from "../lib/sentry";
 import type { ImageFormat } from "@quickconv/shared";
 
 const convertRoute = new Hono();
@@ -25,6 +25,7 @@ convertRoute.post("/", async (c) => {
   const callbackUrl = process.env.CALLBACK_URL;
 
   try {
+    const startTime = Date.now();
     const inputBuffer = await downloadFromR2(inputKey);
     const result = await convertImage({
       inputBuffer,
@@ -32,6 +33,13 @@ convertRoute.post("/", async (c) => {
       outputFormat: outputFormat as any,
     });
     await uploadToR2(outputKey, result.buffer, result.format);
+
+    addConversionBreadcrumb({
+      conversionFormat: `${inputFormat}-to-${outputFormat}`,
+      durationMs: Date.now() - startTime,
+      fileSizeInput: inputBuffer.length,
+      fileSizeOutput: result.size,
+    });
 
     if (callbackUrl) {
       await fetch(callbackUrl, {
@@ -80,6 +88,7 @@ convertRoute.post("/direct", async (c) => {
   }
 
   try {
+    const startTime = Date.now();
     const inputBuffer = Buffer.from(await file.arrayBuffer());
     const inputFormat = file.name.split(".").pop() || "";
 
@@ -87,6 +96,13 @@ convertRoute.post("/direct", async (c) => {
       inputBuffer,
       inputFormat,
       outputFormat: outputFormat as any,
+    });
+
+    addConversionBreadcrumb({
+      conversionFormat: `${inputFormat}-to-${outputFormat}`,
+      durationMs: Date.now() - startTime,
+      fileSizeInput: inputBuffer.length,
+      fileSizeOutput: result.size,
     });
 
     checkMemoryUsage();

--- a/docs/ALERT_RULES.md
+++ b/docs/ALERT_RULES.md
@@ -1,0 +1,150 @@
+# QuickConv Alert Rules
+
+Sentry Dashboard で設定するアラートルールの設計書。
+通知先は全て Pushover（Sentry Webhook Integration 経由）。
+
+## 通知チャネル
+
+| チャネル | 優先度 | 用途 |
+|---|---|---|
+| Pushover (normal) | 0 | 通常通知（音あり） |
+| Pushover (urgent) | 1 | 緊急通知（確認するまで繰り返し通知） |
+
+## アラートルール一覧
+
+### Alert-1: 新規エラー発生
+
+| 項目 | 値 |
+|---|---|
+| トリガー | `first_seen` イベント（新しい Issue が作成された時） |
+| 条件 | 自動（Sentry が新規 Issue を検出） |
+| 通知先 | Pushover (normal) |
+| 重複抑制 | 1 時間 |
+| 対応 | Sentry Dashboard で Issue を確認し、優先度を判断 |
+
+**Sentry 設定手順:**
+1. Alerts > Create Alert > Issues
+2. When: A new issue is created
+3. Then: Send a notification via Pushover Webhook
+4. Action Interval: 60 minutes
+
+### Alert-2: エラースパイク
+
+| 項目 | 値 |
+|---|---|
+| トリガー | 5 分間でイベント 10 件以上 |
+| 条件 | `times_seen` > 10 in 5 minutes |
+| 通知先 | Pushover (urgent) |
+| 重複抑制 | 1 時間 |
+| 対応 | 即座にログ確認。デプロイ直後ならロールバック検討 |
+
+**Sentry 設定手順:**
+1. Alerts > Create Alert > Metric
+2. When: Number of events in 5 minutes > 10
+3. Then: Send a notification via Pushover Webhook (priority=1)
+4. Action Interval: 60 minutes
+
+### Alert-3: OOM 検知（メモリ高使用率）
+
+| 項目 | 値 |
+|---|---|
+| トリガー | メモリ使用率 80% 超（Converter の `checkMemoryUsage` による warning） |
+| 条件 | `message:Memory usage high` AND `level:warning` |
+| 通知先 | Pushover (normal) |
+| 重複抑制 | 1 時間 |
+| 対応 | Cloud Run インスタンスのメモリ設定確認。必要に応じてスケール |
+
+**Sentry 設定手順:**
+1. Alerts > Create Alert > Issues
+2. When: An event's message contains "Memory usage high"
+3. If: The event's level is equal to warning
+4. Then: Send a notification via Pushover Webhook
+5. Action Interval: 60 minutes
+
+### Alert-4: 変換成功率低下
+
+| 項目 | 値 |
+|---|---|
+| トリガー | 変換成功率 95% 未満（5 分間） |
+| 条件 | Sentry Discover クエリで error rate > 5% |
+| 通知先 | Pushover (urgent) |
+| 重複抑制 | 1 時間 |
+| 対応 | Converter ログ確認。特定フォーマットの失敗集中がないか調査 |
+
+**Sentry 設定手順:**
+1. Alerts > Create Alert > Metric
+2. When: Percentage of events with `level:error` AND `service:quickconv-converter` > 5% in 5 minutes
+3. Then: Send a notification via Pushover Webhook (priority=1)
+4. Action Interval: 60 minutes
+
+**Sentry Discover クエリ（手動確認用）:**
+```
+# 変換成功率
+SELECT count_if(level, notEquals, 'error') / count() * 100 AS success_rate
+FROM events
+WHERE service:quickconv-converter AND timestamp > -1h
+```
+
+## カスタムメトリクス活用（Sentry Discover）
+
+E8-6 で追加したカスタムタグを使い、以下のクエリが可能:
+
+```
+# フォーマット別の変換回数
+SELECT conversion_format, count()
+FROM events
+WHERE service:quickconv-converter
+GROUP BY conversion_format
+
+# P95 変換時間
+SELECT p95(conversion_duration_ms)
+FROM events
+WHERE service:quickconv-converter
+
+# レート制限発生率
+SELECT count_if(rate_limited, equals, 'true') / count() * 100 AS rate_limit_pct
+FROM events
+WHERE service:quickconv-api
+```
+
+## Pushover Webhook 設定手順
+
+### 1. Pushover アプリ作成
+
+1. [Pushover Dashboard](https://pushover.net/apps) にログイン
+2. Create an Application/API Token
+3. Application Name: `QuickConv Sentry`
+4. API Token をメモ
+
+### 2. Sentry Integration 設定
+
+1. Sentry > Settings > Integrations > Webhooks
+2. Webhook URL に以下を設定:
+
+```
+https://api.pushover.net/1/messages.json
+```
+
+**注意:** Sentry の Webhook は直接 Pushover API を呼べないため、
+中間の Cloudflare Worker を使用する。
+
+### 3. Pushover Relay Worker（推奨）
+
+Sentry Webhook -> Cloudflare Worker -> Pushover API の構成:
+
+```
+Worker URL: https://sentry-pushover-relay.<your-domain>.workers.dev
+```
+
+Worker は Sentry の Webhook ペイロードを受け取り、
+Pushover API 形式に変換して転送する。
+
+**環境変数（Worker に設定）:**
+- `PUSHOVER_USER_KEY`: Pushover ユーザーキー
+- `PUSHOVER_API_TOKEN`: 上記で作成したアプリトークン
+
+### 4. 動作確認
+
+1. Sentry でテストイベントを送信
+2. Pushover 通知が届くことを確認
+3. urgent 優先度のテスト: Alert-2 または Alert-4 条件を手動トリガー


### PR DESCRIPTION
## Summary
- **E8-6 (#75):** Converter に変換メトリクス（フォーマット、所要時間、入出力ファイルサイズ）の Sentry breadcrumb/tag を追加。API に endpoint と rate_limited タグを追加
- **E8-7 (#76):** 4つのアラートルール設計（新規エラー、エラースパイク、OOM検知、変換成功率低下）と Pushover 通知設定手順を `docs/ALERT_RULES.md` に文書化

## Changed files
- `apps/converter/src/lib/sentry.ts` - `ConversionMetrics` interface + `addConversionBreadcrumb()` 追加
- `apps/converter/src/routes/convert.ts` - R2変換・Direct変換の成功パスにメトリクス送信追加
- `apps/api/src/middleware/sentry.ts` - `endpoint` / `rate_limited` タグ追加
- `docs/ALERT_RULES.md` - アラートルール設計書（新規作成）

## Test plan
- [x] `turbo build` で converter/API ビルド成功
- [x] 既存テスト 67/67 パス（E2E は既知の pre-existing failure）
- [ ] Sentry Dashboard でカスタムタグが表示されることを本番デプロイ後に確認

Closes #75, Closes #76