### PR TITLE
feat: add ICO/TIFF format support

### DIFF
--- a/apps/converter/src/services/image.ts
+++ b/apps/converter/src/services/image.ts
@@ -7,6 +7,7 @@ const DEFAULT_QUALITY: Record<string, number> = {
   jpeg: 85,
   webp: 80,
   avif: 65,
+  tiff: 80,
 };
 
 interface ConvertOptions {
@@ -30,7 +31,9 @@ export interface PreviewResult {
   data: string;
 }
 
-export async function convertImage(options: ConvertOptions): Promise<ConvertResult> {
+export async function convertImage(
+  options: ConvertOptions,
+): Promise<ConvertResult> {
   const { inputBuffer, outputFormat, quality, maxDimension } = options;
 
   let pipeline = sharp(inputBuffer);
@@ -59,6 +62,21 @@ export async function convertImage(options: ConvertOptions): Promise<ConvertResu
       break;
     case "avif":
       pipeline = pipeline.avif({ quality: q ?? 65 });
+      break;
+    case "tiff":
+      pipeline = pipeline.tiff({ compression: "lzw", quality: q ?? 80 });
+      break;
+    case "ico":
+      // ICO is not natively supported by Sharp as output.
+      // Produce a 256x256 PNG buffer; the caller sets Content-Type to image/x-icon.
+      pipeline = pipeline
+        .resize({
+          width: 256,
+          height: 256,
+          fit: "inside",
+          withoutEnlargement: true,
+        })
+        .png({ compressionLevel: 9 });
       break;
     default:
       throw new Error(`Unsupported output format: ${outputFormat}`);
@@ -96,7 +114,9 @@ export async function generatePreviews(
       return {
         quality,
         size: result.size,
-        compressionRatio: parseFloat((1 - result.size / originalSize).toFixed(4)),
+        compressionRatio: parseFloat(
+          (1 - result.size / originalSize).toFixed(4),
+        ),
         data: result.buffer.toString("base64"),
       };
     }),

--- a/packages/shared/src/constants/formats.ts
+++ b/packages/shared/src/constants/formats.ts
@@ -7,6 +7,9 @@ export const MIME_TO_FORMAT: Record<string, string> = {
   "image/heif": "heic",
   "image/gif": "gif",
   "image/svg+xml": "svg",
+  "image/tiff": "tiff",
+  "image/x-icon": "ico",
+  "image/vnd.microsoft.icon": "ico",
 };
 
 export const FORMAT_TO_MIME: Record<string, string> = {
@@ -18,6 +21,8 @@ export const FORMAT_TO_MIME: Record<string, string> = {
   heic: "image/heic",
   gif: "image/gif",
   svg: "image/svg+xml",
+  tiff: "image/tiff",
+  ico: "image/x-icon",
 };
 
 export const ALLOWED_MIME_TYPES = Object.keys(MIME_TO_FORMAT);

--- a/packages/shared/src/types/conversion.ts
+++ b/packages/shared/src/types/conversion.ts
@@ -1,15 +1,28 @@
-export const IMAGE_FORMATS = ["jpg", "jpeg", "png", "webp", "avif", "heic", "gif", "svg"] as const;
+export const IMAGE_FORMATS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+  "avif",
+  "heic",
+  "gif",
+  "svg",
+  "tiff",
+  "ico",
+] as const;
 export type ImageFormat = (typeof IMAGE_FORMATS)[number];
 
 export const CONVERSION_PAIRS: Record<string, ImageFormat[]> = {
   heic: ["jpg", "png", "webp"],
   avif: ["jpg", "png", "webp"],
-  webp: ["jpg", "png"],
-  png: ["jpg", "webp", "avif"],
-  jpg: ["png", "webp", "avif"],
-  jpeg: ["png", "webp", "avif"],
+  webp: ["jpg", "png", "tiff"],
+  png: ["jpg", "webp", "avif", "ico", "tiff"],
+  jpg: ["png", "webp", "avif", "ico", "tiff"],
+  jpeg: ["png", "webp", "avif", "ico", "tiff"],
   gif: ["jpg", "png", "webp"],
   svg: ["png", "jpg", "webp"],
+  tiff: ["jpg", "png", "webp"],
+  ico: ["png", "jpg"],
 };
 
 export type JobStatus = "pending" | "processing" | "completed" | "failed";


### PR DESCRIPTION
## Summary
- Add TIFF and ICO as supported image formats across all layers (shared, converter, API, web)
- TIFF output uses Sharp's native `tiff()` with LZW compression and quality 80
- ICO output produces a 256x256 PNG buffer (Sharp lacks native ICO output), served with `image/x-icon` Content-Type
- TIFF/ICO input is natively supported by Sharp, no additional handling needed
- MIME types added: `image/tiff`, `image/x-icon`, `image/vnd.microsoft.icon`
- New conversion pairs: `tiff->jpg/png/webp`, `ico->png/jpg`, and `ico/tiff` added as targets from `png/jpg/webp`

## Changed files
- `packages/shared/src/types/conversion.ts` - IMAGE_FORMATS and CONVERSION_PAIRS extended
- `packages/shared/src/constants/formats.ts` - MIME_TO_FORMAT and FORMAT_TO_MIME extended
- `apps/converter/src/services/image.ts` - TIFF/ICO output handling in convertImage()

## Test plan
- [ ] Upload a TIFF file and convert to JPG/PNG/WebP
- [ ] Upload an ICO file and convert to PNG/JPG
- [ ] Upload a PNG/JPG and convert to TIFF (verify LZW compression)
- [ ] Upload a PNG/JPG and convert to ICO (verify 256x256 output)
- [ ] Verify new format pages are auto-generated (e.g. /convert/tiff-to-jpg)
- [ ] Verify existing conversions still work (no regression)

Closes #144