### PR TITLE
feat: MP4→GIF変換の基盤追加 (FFmpeg + 型定義)

### DIFF
--- a/apps/converter/Dockerfile
+++ b/apps/converter/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libvips-dev \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/apps/converter/dist ./dist

--- a/packages/shared/src/constants/formats.ts
+++ b/packages/shared/src/constants/formats.ts
@@ -10,6 +10,7 @@ export const MIME_TO_FORMAT: Record<string, string> = {
   "image/tiff": "tiff",
   "image/x-icon": "ico",
   "image/vnd.microsoft.icon": "ico",
+  "video/mp4": "mp4",
 };
 
 export const FORMAT_TO_MIME: Record<string, string> = {
@@ -23,6 +24,7 @@ export const FORMAT_TO_MIME: Record<string, string> = {
   svg: "image/svg+xml",
   tiff: "image/tiff",
   ico: "image/x-icon",
+  mp4: "video/mp4",
 };
 
 export const ALLOWED_MIME_TYPES = Object.keys(MIME_TO_FORMAT);

--- a/packages/shared/src/types/conversion.ts
+++ b/packages/shared/src/types/conversion.ts
@@ -12,7 +12,14 @@ export const IMAGE_FORMATS = [
 ] as const;
 export type ImageFormat = (typeof IMAGE_FORMATS)[number];
 
-export const CONVERSION_PAIRS: Record<string, ImageFormat[]> = {
+export const VIDEO_FORMATS = ["mp4"] as const;
+export type VideoFormat = (typeof VIDEO_FORMATS)[number];
+
+export type OutputFormat = ImageFormat;
+export const ALL_FORMATS = [...IMAGE_FORMATS, ...VIDEO_FORMATS] as const;
+export type AllFormat = (typeof ALL_FORMATS)[number];
+
+export const CONVERSION_PAIRS: Record<string, OutputFormat[]> = {
   heic: ["jpg", "png", "webp"],
   avif: ["jpg", "png", "webp"],
   webp: ["jpg", "png", "tiff"],
@@ -23,6 +30,7 @@ export const CONVERSION_PAIRS: Record<string, ImageFormat[]> = {
   svg: ["png", "jpg", "webp"],
   tiff: ["jpg", "png", "webp"],
   ico: ["png", "jpg"],
+  mp4: ["gif"],
 };
 
 export type JobStatus = "pending" | "processing" | "completed" | "failed";


### PR DESCRIPTION
## Summary
- Dockerfile の本番ステージに FFmpeg パッケージを追加（動画変換エンジン）
- shared パッケージに VIDEO_FORMATS 型定義、mp4→gif 変換ペア、video/mp4 MIMEマッピングを追加

Closes #148, Closes #149

## 変更ファイル
- `apps/converter/Dockerfile` - ffmpeg インストール追加
- `packages/shared/src/types/conversion.ts` - VIDEO_FORMATS, VideoFormat, AllFormat, ALL_FORMATS, mp4→gif ペア追加
- `packages/shared/src/constants/formats.ts` - video/mp4 MIMEマッピング追加

## Test plan
- [x] shared パッケージビルド成功
- [x] converter パッケージビルド成功
- [ ] Docker ビルド確認（CI）