### PR TITLE
feat: add MP4 video upload support

### DIFF
--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -5,7 +5,9 @@ import {
   ALLOWED_MIME_TYPES,
   MAX_FILE_SIZE_BYTES,
   ANONYMOUS_MAX_FILE_SIZE_BYTES,
+  ANONYMOUS_MAX_VIDEO_FILE_SIZE_BYTES,
   ANONYMOUS_MAX_BATCH_FILES,
+  isVideoMimeType,
 } from "@quickconv/shared";
 import type { Env, AppVariables } from "../types/env";
 import { uploadToR2 } from "../services/r2";
@@ -37,13 +39,17 @@ upload.post("/", async (c) => {
     return c.json({ error: "validation", message: "No file provided" }, 400);
   }
 
-  // 匿名ユーザーの10MB制限（ボディパース後の実サイズチェック）
-  if (file.size > ANONYMOUS_MAX_FILE_SIZE_BYTES) {
+  // 匿名ユーザーのサイズ制限（動画: 5MB, 画像: 10MB）
+  const maxSizeForAnonymous = isVideoMimeType(file.type)
+    ? ANONYMOUS_MAX_VIDEO_FILE_SIZE_BYTES
+    : ANONYMOUS_MAX_FILE_SIZE_BYTES;
+
+  if (file.size > maxSizeForAnonymous) {
     return c.json(
       {
         error: "file_too_large",
-        message: `File size exceeds ${ANONYMOUS_MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB limit`,
-        maxSizeBytes: ANONYMOUS_MAX_FILE_SIZE_BYTES,
+        message: `File size exceeds ${maxSizeForAnonymous / (1024 * 1024)}MB limit`,
+        maxSizeBytes: maxSizeForAnonymous,
       },
       413,
     );

--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   ArrowLeft,
   Eye,
+  FileVideo,
 } from "lucide-react";
 import { FileDropzone } from "./file-dropzone";
 import { FormatSelector } from "./format-selector";
@@ -22,7 +23,7 @@ import { ImageCompareSlider } from "./image-compare-slider";
 import { useConversion } from "@/hooks/use-conversion";
 import { useSubscription } from "@/hooks/use-subscription";
 import { useGAEvent } from "@/hooks/use-ga-event";
-import { FREE_PREVIEW_LIMIT } from "@quickconv/shared";
+import { FREE_PREVIEW_LIMIT, isVideoMimeType } from "@quickconv/shared";
 import type { ImageFormat } from "@quickconv/shared";
 
 /** Warning threshold: show warning when remaining <= this value */
@@ -56,6 +57,7 @@ export function ConversionCard() {
   } = useConversion();
   const { trackFileDownload } = useGAEvent();
 
+  const isVideo = file ? isVideoMimeType(file.type) : false;
   const isRateLimited = remainingConversions !== null && remainingConversions <= 0;
   const isLowRemaining =
     remainingConversions !== null &&
@@ -152,11 +154,14 @@ export function ConversionCard() {
           />
 
           {file && (
-            <div className="rounded-lg bg-muted p-4">
-              <p className="text-sm font-medium">{file.name}</p>
-              <p className="text-xs text-muted-foreground">
-                {(file.size / 1024 / 1024).toFixed(2)} MB
-              </p>
+            <div className="rounded-lg bg-muted p-4 flex items-center gap-3">
+              {isVideo && <FileVideo className="h-8 w-8 text-muted-foreground flex-shrink-0" />}
+              <div>
+                <p className="text-sm font-medium">{file.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {(file.size / 1024 / 1024).toFixed(2)} MB
+                </p>
+              </div>
             </div>
           )}
 
@@ -175,20 +180,24 @@ export function ConversionCard() {
                 {t("startConversion")}
               </button>
 
-              {/* Compare Quality button */}
-              <button
-                onClick={handleCompareQuality}
-                className="w-full py-2.5 rounded-lg font-medium transition-colors border border-border text-foreground hover:bg-muted flex items-center justify-center gap-2"
-              >
-                <Eye className="h-4 w-4" />
-                {tp("compareQuality")}
-              </button>
+              {/* Compare Quality button (image only, not for video) */}
+              {!isVideo && (
+                <>
+                  <button
+                    onClick={handleCompareQuality}
+                    className="w-full py-2.5 rounded-lg font-medium transition-colors border border-border text-foreground hover:bg-muted flex items-center justify-center gap-2"
+                  >
+                    <Eye className="h-4 w-4" />
+                    {tp("compareQuality")}
+                  </button>
 
-              {/* Teaser for free users */}
-              {!isPaid && (
-                <p className="text-xs text-muted-foreground text-center">
-                  {tp("freeTeaser")}
-                </p>
+                  {/* Teaser for free users */}
+                  {!isPaid && (
+                    <p className="text-xs text-muted-foreground text-center">
+                      {tp("freeTeaser")}
+                    </p>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -13,7 +13,7 @@
     "failed": "Conversion failed",
     "dragDrop": "Drag & drop files here, or click to select",
     "maxSize": "Max file size: {size}MB",
-    "supportedFormats": "Supported: JPG, PNG, WebP, AVIF, HEIC, GIF, SVG",
+    "supportedFormats": "Supported: JPG, PNG, WebP, AVIF, HEIC, GIF, SVG, MP4",
     "selectFormat": "Convert to",
     "startConversion": "Start Conversion",
     "downloadFile": "Download",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -13,7 +13,7 @@
     "failed": "変換に失敗しました",
     "dragDrop": "ファイルをドラッグ＆ドロップ、またはクリックして選択",
     "maxSize": "最大ファイルサイズ: {size}MB",
-    "supportedFormats": "対応形式: JPG, PNG, WebP, AVIF, HEIC, GIF, SVG",
+    "supportedFormats": "対応形式: JPG, PNG, WebP, AVIF, HEIC, GIF, SVG, MP4",
     "selectFormat": "変換先",
     "startConversion": "変換開始",
     "downloadFile": "ダウンロード",

--- a/packages/shared/src/constants/formats.ts
+++ b/packages/shared/src/constants/formats.ts
@@ -28,3 +28,9 @@ export const FORMAT_TO_MIME: Record<string, string> = {
 };
 
 export const ALLOWED_MIME_TYPES = Object.keys(MIME_TO_FORMAT);
+
+export const VIDEO_MIME_TYPES = ALLOWED_MIME_TYPES.filter((m) => m.startsWith("video/"));
+
+export function isVideoMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("video/");
+}

--- a/packages/shared/src/types/rate-limit.ts
+++ b/packages/shared/src/types/rate-limit.ts
@@ -6,6 +6,9 @@ export const ANONYMOUS_DAILY_LIMIT = 10;
 /** 匿名ユーザーの1ファイルあたり最大サイズ (10MB) */
 export const ANONYMOUS_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
+/** 匿名ユーザーの動画1ファイルあたり最大サイズ (5MB) */
+export const ANONYMOUS_MAX_VIDEO_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
 /** 匿名ユーザーの1バッチあたり最大ファイル数 */
 export const ANONYMOUS_MAX_BATCH_FILES = 3;
 


### PR DESCRIPTION
## Summary
- Add MP4 video file upload support across API and web frontend
- Free users: 5MB video size limit (vs 10MB for images)
- i18n: MP4 added to supported format text (en/ja)
- Video files show FileVideo icon and hide image-only quality comparison feature

## Changes
- `packages/shared`: `ANONYMOUS_MAX_VIDEO_FILE_SIZE_BYTES`, `isVideoMimeType()`, `VIDEO_MIME_TYPES`
- `apps/api/upload.ts`: differentiate size limit by media type
- `apps/web/conversion-card.tsx`: video icon, hide quality compare for video
- `apps/web/messages/{en,ja}.json`: MP4 in supportedFormats

## Test plan
- [ ] Upload MP4 file and verify it succeeds
- [ ] Upload MP4 > 5MB as free user and verify rejection (413)
- [ ] Upload image file and verify existing 10MB limit still applies
- [ ] Verify MP4 file shows FileVideo icon in conversion card
- [ ] Verify quality comparison button is hidden for video files
- [ ] Verify supportedFormats text includes MP4 in both en/ja

Closes #151