### PR TITLE
chore: add GA4 measurement ID to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # Ad layout A/B test: "default" | "variant-a" | "variant-b"
 NEXT_PUBLIC_AD_LAYOUT=default
 
+# Google Analytics 4
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
 # Converter (Cloud Run)
 API_KEY=your-secret-api-key
 R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com


### PR DESCRIPTION
## Summary
- `.env.example` に `NEXT_PUBLIC_GA_MEASUREMENT_ID` 環境変数のプレースホルダーを追加
- Cloudflare Pages の Production/Preview 環境変数に実際の測定ID（G-PTDR3MNDW8）を設定済み

Closes #47

## Test plan
- [ ] Cloudflare Pages で再デプロイ後、quickconv.cc にアクセス
- [ ] Cookie同意 → GA4 リアルタイムで page_view 確認
- [ ] DevTools Network で gtag リクエスト確認
- [ ] Cookie同意前に gtag.js が未ロードであることを確認