### PR TITLE
ci: add automatic Cloudflare Pages deploy on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,30 @@ jobs:
       - name: Run unit tests
         run: cd apps/api && pnpm test
 
+  deploy-web:
+    runs-on: ubuntu-latest
+    needs: [lint-and-build, test]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Build web
+        env:
+          NEXT_PUBLIC_GA_MEASUREMENT_ID: ${{ vars.NEXT_PUBLIC_GA_MEASUREMENT_ID }}
+          NEXT_PUBLIC_API_URL: https://api.quickconv.cc
+          NEXT_PUBLIC_SITE_URL: https://quickconv.cc
+        run: pnpm run build --filter=@quickconv/web
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler pages deploy apps/web/out --project-name quickconv-web
+
   e2e:
     if: false
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- CI に `deploy-web` ジョブを追加。main push 時に lint/test 通過後、自動で Cloudflare Pages にデプロイ
- GA4 測定IDを含む環境変数をビルド時に注入
- GitHub Secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` 設定済み
- GitHub Variables: `NEXT_PUBLIC_GA_MEASUREMENT_ID` 設定済み

## Test plan
- [ ] PR マージ後、CI の deploy-web ジョブが成功すること
- [ ] デプロイ後 quickconv.cc で GA4 が動作すること