### PR TITLE
feat(infra): add staging environment

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -23,3 +23,27 @@ binding = "DB"
 database_name = "quickconv-db"
 database_id = "d3782b06-5151-44b0-9255-49982c2e2a2f"
 migrations_dir = "src/db/migrations"
+
+# ─── Staging Environment ───
+[env.staging]
+name = "quickconv-api-staging"
+workers_dev = true
+routes = [
+  { pattern = "api-staging.quickconv.cc", custom_domain = true }
+]
+
+[env.staging.vars]
+CORS_ORIGIN = "https://quickconv.cc,https://www.quickconv.cc,https://quickconv-web.pages.dev,https://*.quickconv-web.pages.dev"
+CONVERTER_URL = "https://quickconv-converter-896908237738.us-central1.run.app"
+APP_URL = "https://api-staging.quickconv.cc"
+FRONTEND_URL = "https://quickconv-web.pages.dev"
+
+[[env.staging.r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "quickconv-files"
+
+[[env.staging.d1_databases]]
+binding = "DB"
+database_name = "quickconv-db-staging"
+database_id = "STAGING_DB_ID_HERE"
+migrations_dir = "src/db/migrations"

--- a/apps/web/.env.staging
+++ b/apps/web/.env.staging
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=https://api-staging.quickconv.cc
+NEXT_PUBLIC_SITE_URL=https://quickconv-web.pages.dev

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -12,7 +12,7 @@ npx turbo build --filter=@quickconv/web       # フロントのみ
 npx turbo build --filter=@quickconv/api       # APIのみ
 ```
 
-## デプロイ
+## デプロイ（本番）
 ```bash
 # API (Cloudflare Workers)
 npx wrangler deploy --config apps/api/wrangler.toml
@@ -22,4 +22,70 @@ npx wrangler pages deploy apps/web/out --project-name quickconv-web
 
 # Converter (GCP Cloud Run)
 gcloud builds submit --config=cloudbuild.yaml .
+```
+
+## ステージング環境
+
+### 構成
+| コンポーネント | 本番 | ステージング |
+|---|---|---|
+| Frontend | quickconv.cc | *.quickconv-web.pages.dev (プレビュー) |
+| API | api.quickconv.cc | api-staging.quickconv.cc |
+| DB | quickconv-db (D1) | quickconv-db-staging (D1) |
+| Storage | quickconv-files (R2) | quickconv-files (R2, 共有) |
+| Converter | Cloud Run | Cloud Run (共有) |
+
+### 初回セットアップ
+
+#### 1. D1 ステージングDB作成
+```bash
+npx wrangler d1 create quickconv-db-staging
+```
+作成後、出力された `database_id` を `apps/api/wrangler.toml` の `[env.staging.d1_databases]` セクションの `database_id` に設定する。
+
+#### 2. マイグレーション適用
+```bash
+npx wrangler d1 migrations apply quickconv-db-staging --remote --env staging
+```
+
+#### 3. シークレット設定
+```bash
+# Google OAuth
+npx wrangler secret put GOOGLE_CLIENT_ID --env staging
+npx wrangler secret put GOOGLE_CLIENT_SECRET --env staging
+
+# JWT
+npx wrangler secret put JWT_SECRET --env staging
+
+# Stripe (テストモードのキーを使用)
+npx wrangler secret put STRIPE_SECRET_KEY --env staging
+npx wrangler secret put STRIPE_WEBHOOK_SECRET --env staging
+
+# Sentry (任意)
+npx wrangler secret put SENTRY_DSN --env staging
+```
+
+#### 4. Google OAuth リダイレクトURI追加
+GCP Console > APIs & Credentials > OAuth 2.0 Client で以下を追加:
+- `https://api-staging.quickconv.cc/auth/google/callback`
+
+### デプロイ（ステージング）
+
+```bash
+# API
+npx wrangler deploy --config apps/api/wrangler.toml --env staging
+
+# Frontend (プレビューデプロイ)
+cp apps/web/.env.staging apps/web/.env.production.local
+npx turbo build --filter=@quickconv/web
+npx wrangler pages deploy apps/web/out --project-name quickconv-web --branch staging
+```
+
+### 動作確認
+```bash
+# API ヘルスチェック
+curl https://api-staging.quickconv.cc/health
+
+# Workers dev URL でも確認可能
+# https://quickconv-api-staging.<account>.workers.dev
 ```


### PR DESCRIPTION
## Summary
- `wrangler.toml` に `[env.staging]` セクションを追加（staging用 D1/R2/CORS/URL設定）
- `apps/web/.env.staging` を作成（ステージングAPI向け環境変数）
- `docs/deploy.md` にステージング環境の構成表・初回セットアップ手順・デプロイ手順・動作確認方法を追記

## 残作業（マージ後に手動実施）
1. `npx wrangler d1 create quickconv-db-staging` でD1作成 → `database_id` を `wrangler.toml` に反映
2. `npx wrangler d1 migrations apply quickconv-db-staging --remote --env staging` でマイグレーション適用
3. `wrangler secret put` で各シークレット設定（Google OAuth, JWT, Stripe）
4. GCP Console で OAuth リダイレクトURI追加: `https://api-staging.quickconv.cc/auth/google/callback`
5. `npx wrangler deploy --config apps/api/wrangler.toml --env staging` でデプロイ

## Test plan
- [ ] wrangler.toml の staging 設定が valid であること（`npx wrangler deploy --dry-run --env staging`）
- [ ] D1作成後、database_id 置換 → マイグレーション適用 → デプロイ成功
- [ ] `curl https://api-staging.quickconv.cc/health` で 200 返却
- [ ] フロントエンドのプレビューデプロイからステージングAPI接続確認

Closes #163