### PR TITLE
fix(web): load GA4 immediately after cookie consent without reload

### DIFF
--- a/apps/web/e2e/cookie-ga4.spec.ts
+++ b/apps/web/e2e/cookie-ga4.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+const GA_SCRIPT_URL = "googletagmanager.com/gtag/js";
+
+test.describe("Cookie consent and GA4 integration", () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear cookie consent state before each test
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("qc_cookie_consent"));
+    await page.reload();
+  });
+
+  test("GA4 script is NOT loaded before cookie consent", async ({ page }) => {
+    // Wait for page to fully load
+    await expect(page).toHaveTitle(/QuickConv/i);
+
+    // Verify cookie consent banner is visible
+    const acceptButton = page.getByRole("button", { name: /accept/i });
+    await expect(acceptButton).toBeVisible({ timeout: 10_000 });
+
+    // Verify GA4 script is NOT present
+    const gaScript = page.locator(`script[src*="${GA_SCRIPT_URL}"]`);
+    await expect(gaScript).toHaveCount(0);
+  });
+
+  test("GA4 script loads immediately after accepting cookies (no reload)", async ({
+    page,
+  }) => {
+    await expect(page).toHaveTitle(/QuickConv/i);
+
+    // Set up a promise to detect the GA4 network request
+    const gaRequestPromise = page.waitForRequest(
+      (req) => req.url().includes(GA_SCRIPT_URL),
+      { timeout: 10_000 },
+    );
+
+    // Click accept
+    const acceptButton = page.getByRole("button", { name: /accept/i });
+    await expect(acceptButton).toBeVisible({ timeout: 10_000 });
+    await acceptButton.click();
+
+    // Verify GA4 script request was made (without reload)
+    const gaRequest = await gaRequestPromise;
+    expect(gaRequest.url()).toContain(GA_SCRIPT_URL);
+  });
+
+  test("GA4 script does NOT load after rejecting cookies", async ({
+    page,
+  }) => {
+    await expect(page).toHaveTitle(/QuickConv/i);
+
+    // Click reject
+    const rejectButton = page.getByRole("button", { name: /reject|decline/i });
+    await expect(rejectButton).toBeVisible({ timeout: 10_000 });
+    await rejectButton.click();
+
+    // Wait a bit for any potential async loading
+    await page.waitForTimeout(2_000);
+
+    // Verify GA4 script is NOT present
+    const gaScript = page.locator(`script[src*="${GA_SCRIPT_URL}"]`);
+    await expect(gaScript).toHaveCount(0);
+  });
+});

--- a/apps/web/src/components/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent.tsx
@@ -20,11 +20,17 @@ export function CookieConsent() {
 
   const handleAccept = () => {
     localStorage.setItem(STORAGE_KEY, "accepted");
+    window.dispatchEvent(
+      new CustomEvent("cookie-consent-change", { detail: "accepted" }),
+    );
     setVisible(false);
   };
 
   const handleReject = () => {
     localStorage.setItem(STORAGE_KEY, "rejected");
+    window.dispatchEvent(
+      new CustomEvent("cookie-consent-change", { detail: "rejected" }),
+    );
     setVisible(false);
   };
 

--- a/apps/web/src/components/google-analytics.tsx
+++ b/apps/web/src/components/google-analytics.tsx
@@ -19,18 +19,32 @@ export function GoogleAnalytics() {
   const pathname = usePathname();
   const [consentGiven, setConsentGiven] = useState(false);
 
-  // Check consent on mount and listen for storage changes
+  // Check consent on mount and listen for consent changes
   useEffect(() => {
     setConsentGiven(hasConsentAccepted());
 
+    // Same-tab consent changes via custom event
+    const handleConsentChange = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      setConsentGiven(detail === "accepted");
+    };
+
+    // Cross-tab consent changes via storage event
     const handleStorage = (e: StorageEvent) => {
       if (e.key === "qc_cookie_consent") {
         setConsentGiven(e.newValue === "accepted");
       }
     };
 
+    window.addEventListener("cookie-consent-change", handleConsentChange);
     window.addEventListener("storage", handleStorage);
-    return () => window.removeEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener(
+        "cookie-consent-change",
+        handleConsentChange,
+      );
+      window.removeEventListener("storage", handleStorage);
+    };
   }, []);
 
   // Send pageview on SPA navigation


### PR DESCRIPTION
## Summary
Cookie同意バナーで「Accept」を押した後、ページリロードなしでGA4を即座にロードするよう修正。

## 根本原因
`StorageEvent` は同一タブ内の `localStorage.setItem()` では発火しない（別タブでの変更のみ）。そのため、Cookie同意後もGA4コンポーネントに通知されなかった。

## 修正内容
- `cookie-consent.tsx`: Accept/Reject時に `CustomEvent("cookie-consent-change")` をディスパッチ
- `google-analytics.tsx`: カスタムイベントをリッスンして `consentGiven` を即座に更新
- E2Eテスト追加: `cookie-ga4.spec.ts`（同意前/同意後/拒否後の3ケース）

## Test plan
- [x] pnpm build 成功
- [x] smoke テスト PASS
- [ ] cookie-ga4 E2Eテスト（デプロイ後に確認）

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)