### PR TITLE
fix(infra): set Cloud Run max-instances=1 for cost control

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,5 +18,6 @@ steps:
       - '--platform=managed'
       - '--allow-unauthenticated'
       - '--timeout=500'
+      - '--max-instances=1'
 images:
   - 'us-central1-docker.pkg.dev/quickconv-489717/quickconv/converter'


### PR DESCRIPTION
Cloud Run max-instances=3→1に変更。動画変換の同時処理によるコストスパイクを防止。

Closes #184 (部分対応: AC-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)