### PR TITLE
feat(infra): complete staging environment (Closes #163)

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -45,5 +45,5 @@ bucket_name = "quickconv-files"
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "quickconv-db-staging"
-database_id = "STAGING_DB_ID_HERE"
+database_id = "dd4292b1-6432-47ab-a63f-6069610cd72e"
 migrations_dir = "src/db/migrations"


### PR DESCRIPTION
## Summary
ステージング環境のセットアップ完了。

### 構成
| 環境 | Frontend | API | DB |
|------|----------|-----|----|
| 本番 | quickconv.cc | api.quickconv.cc | quickconv-db |
| **ステージング** | *.quickconv-web.pages.dev | **api-staging.quickconv.cc** | **quickconv-db-staging** |

### 完了
- [x] D1 staging DB 作成・全8マイグレーション適用
- [x] staging API デプロイ（api-staging.quickconv.cc）
- [x] シークレット設定（CONVERTER_API_KEY, JWT_SECRET, GOOGLE_CLIENT_ID）
- [x] ヘルスチェック通過

### ユーザー手動作業（残り）
1. `GOOGLE_CLIENT_SECRET` をステージングに設定
2. GCPコンソールでリダイレクトURI追加

## Test plan
- [x] staging API /health → 200
- [x] staging API /api/auth/me → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)