### PR TITLE
feat(ux): ベネフィットバッジ・広告位置修正・ヒーローコピー改善

### DIFF
--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { ConversionCard } from "@/components/conversion-card";
 import { PopularConversions } from "@/components/popular-conversions";
+import { HeroHeadline } from "@/components/hero-headline";
 import { WebApplicationJsonLd } from "@/components/json-ld";
 import { buildPageMetadata } from "@/lib/metadata";
 import { locales, type Locale } from "@/lib/i18n/config";
@@ -44,7 +45,7 @@ export default async function HomePage({
         description={tJsonLd("webAppDescription")}
       />
       <div className="text-center mb-10">
-        <h1 className="text-4xl font-bold tracking-tight">{t("tagline")}</h1>
+        <HeroHeadline />
         <p className="mt-3 text-lg text-muted-foreground">
           {t("description")}
         </p>

--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -11,6 +11,9 @@ import {
   Eye,
   FileVideo,
   FileAudio,
+  Shield,
+  Clock,
+  Trash2,
 } from "lucide-react";
 import { FileDropzone } from "./file-dropzone";
 import { FormatSelector } from "./format-selector";
@@ -158,6 +161,9 @@ export function ConversionCard() {
             onFileSelect={handleFileSelect}
             remainingConversions={remainingConversions}
           />
+
+          {/* Benefit badges */}
+          <BenefitBadges />
 
           {file && (
             <div className="rounded-lg bg-muted p-4 flex items-center gap-3">
@@ -344,9 +350,6 @@ export function ConversionCard() {
             </span>
           )}
 
-          {/* Ad: Rectangle above download button */}
-          <AdSlot slot="completed-rectangle" placement="rectangle" className="my-2" />
-
           <a
             href={downloadUrl}
             download
@@ -360,6 +363,9 @@ export function ConversionCard() {
 
           {/* Share buttons */}
           <ShareButtons from={inputFormat} to={convOutputFormat} />
+
+          {/* Ad: Rectangle below download button */}
+          <AdSlot slot="completed-rectangle" placement="rectangle" className="mt-2" />
 
           <button
             onClick={handleReset}
@@ -400,6 +406,29 @@ export function ConversionCard() {
           dailyLimit={dailyLimit}
         />
       )}
+    </div>
+  );
+}
+
+function BenefitBadges() {
+  const t = useTranslations("common");
+  const badges = [
+    { icon: Clock, label: t("benefitFast") },
+    { icon: Shield, label: t("benefitNoSignup") },
+    { icon: Trash2, label: t("benefitAutoDelete") },
+  ] as const;
+
+  return (
+    <div className="flex flex-wrap justify-center gap-3">
+      {badges.map(({ icon: Icon, label }) => (
+        <span
+          key={label}
+          className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground"
+        >
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </span>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/components/hero-headline.tsx
+++ b/apps/web/src/components/hero-headline.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+
+const VARIANT_KEYS = [
+  "taglineVariant1",
+  "taglineVariant2",
+  "taglineVariant3",
+] as const;
+
+const STORAGE_KEY = "hero_variant";
+
+export function HeroHeadline() {
+  const t = useTranslations("common");
+  const [variantIndex, setVariantIndex] = useState(0);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (stored !== null) {
+      setVariantIndex(Number(stored));
+    } else {
+      const idx = Math.floor(Math.random() * VARIANT_KEYS.length);
+      sessionStorage.setItem(STORAGE_KEY, String(idx));
+      setVariantIndex(idx);
+    }
+  }, []);
+
+  const key = VARIANT_KEYS[variantIndex];
+
+  return (
+    <h1 className="text-4xl font-bold tracking-tight" data-variant={key}>
+      {t(key)}
+    </h1>
+  );
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -3,8 +3,11 @@
     "siteName": "QuickConv",
     "login": "Sign in",
     "logout": "Sign out",
-    "tagline": "Fast, Free Online Image Converter",
-    "description": "Convert images between HEIC, WebP, AVIF, PNG, JPG formats instantly. Free, no registration required.",
+    "tagline": "Can't Open That Image? Convert It Instantly.",
+    "description": "HEIC from iPhone, WebP from the web, AVIF that won't open — convert to JPG or PNG in seconds. Free, no signup needed.",
+    "taglineVariant1": "Can't Open That Image? Convert It Instantly.",
+    "taglineVariant2": "iPhone Photos Won't Open? Fix It in 3 Seconds.",
+    "taglineVariant3": "WebP, AVIF, HEIC — Open Any Image, Anywhere.",
     "upload": "Upload",
     "convert": "Convert",
     "download": "Download",
@@ -41,7 +44,10 @@
     "readMore": "Read more",
     "tryConverter": "Try It Free",
     "tableOfContents": "Table of Contents",
-    "contact": "Contact"
+    "contact": "Contact",
+    "benefitFast": "Convert in seconds",
+    "benefitNoSignup": "No signup required",
+    "benefitAutoDelete": "Auto-deleted in 24h"
   },
   "seo": {
     "homeTitle": "QuickConv - Free Online Image Converter | WebP AVIF HEIC",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -3,8 +3,11 @@
     "siteName": "QuickConv",
     "login": "ログイン",
     "logout": "ログアウト",
-    "tagline": "高速・無料のオンライン画像変換",
-    "description": "HEIC、WebP、AVIF、PNG、JPG形式の画像を瞬時に変換。無料、登録不要。",
+    "tagline": "その画像、開けない？ 今すぐ変換。",
+    "description": "iPhoneのHEIC、WebサイトのWebP、開けないAVIF — JPGやPNGに数秒で変換。無料・登録不要。",
+    "taglineVariant1": "その画像、開けない？ 今すぐ変換。",
+    "taglineVariant2": "iPhoneの写真が開けない？ 3秒で解決。",
+    "taglineVariant3": "WebP・AVIF・HEIC — どんな画像も、どこでも開ける。",
     "upload": "アップロード",
     "convert": "変換",
     "download": "ダウンロード",
@@ -41,7 +44,10 @@
     "readMore": "続きを読む",
     "tryConverter": "無料で試す",
     "tableOfContents": "目次",
-    "contact": "お問い合わせ"
+    "contact": "お問い合わせ",
+    "benefitFast": "数秒で変換",
+    "benefitNoSignup": "登録不要",
+    "benefitAutoDelete": "24時間で自動削除"
   },
   "seo": {
     "homeTitle": "QuickConv - 無料オンライン画像変換 | WebP AVIF HEIC対応",


### PR DESCRIPTION
## Summary
- **#209 ベネフィットバッジ**: ドロップゾーン直下に Shield/Clock/Trash2 アイコン付き3バッジ配置（数秒変換・登録不要・24h自動削除）
- **#210 広告位置修正**: AdSlot をDLボタン+シェアボタンの下に移動、CTA を妨げない配置に
- **#211 ヒーローコピー**: 具体的ペインに訴求するコピーに変更（「その画像、開けない？」等）、sessionStorage ベースの A/B テスト対応（3バリアント、`data-variant` 属性で GA4 計測可能）

Closes #209
Closes #210
Closes #211

## Test plan
- [x] `pnpm build` 成功
- [x] `pnpm lint` パス
- [ ] モバイルでバッジが折り返し表示されることを確認
- [ ] DLボタンが広告より上に表示されることを確認
- [ ] ヒーローコピーがセッションごとにランダム切り替えされることを確認
- [ ] ステージング E2E 確認