### PR TITLE
fix(ux): UXポリッシュ — DL全幅化・リトライ・モバイルパディング・アップセル

### DIFF
--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -14,6 +14,8 @@ import {
   Shield,
   Clock,
   Trash2,
+  CheckCircle2,
+  RotateCcw,
 } from "lucide-react";
 import { FileDropzone } from "./file-dropzone";
 import { FormatSelector } from "./format-selector";
@@ -212,6 +214,17 @@ export function ConversionCard() {
                   )}
                 </>
               )}
+
+              {/* Soft upsell when remaining <= 3 */}
+              {isLowRemaining && (
+                <p className="text-xs text-center text-yellow-700 dark:text-yellow-300">
+                  {t("softUpsell", { remaining: remainingConversions })}
+                  {" "}
+                  <a href="/pricing" className="underline font-medium hover:text-yellow-900 dark:hover:text-yellow-100">
+                    {t("softUpsellLink")}
+                  </a>
+                </p>
+              )}
             </div>
           )}
 
@@ -330,8 +343,8 @@ export function ConversionCard() {
       {/* Step 4: Completed */}
       {step === "completed" && downloadUrl && (
         <div className="rounded-xl border border-border p-8 text-center space-y-4">
-          <div className="mx-auto h-12 w-12 rounded-full bg-green-100 flex items-center justify-center">
-            <Download className="h-6 w-6 text-green-600" />
+          <div className="mx-auto h-12 w-12 rounded-full bg-green-100 flex items-center justify-center animate-in zoom-in duration-300">
+            <CheckCircle2 className="h-6 w-6 text-green-600" />
           </div>
           <p className="font-medium text-green-600">{t("completed")}</p>
 
@@ -354,7 +367,7 @@ export function ConversionCard() {
             href={downloadUrl}
             download
             onClick={() => trackFileDownload(inputFormat, convOutputFormat)}
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
+            className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
           >
             <Download className="h-4 w-4" />
             {t("downloadFile")}
@@ -383,13 +396,24 @@ export function ConversionCard() {
           <AlertCircle className="mx-auto h-8 w-8 text-destructive" />
           <p className="font-medium text-destructive">{t("failed")}</p>
           {error && <p className="text-sm text-muted-foreground">{error}</p>}
-          <button
-            onClick={handleReset}
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
-          >
-            <RefreshCw className="h-4 w-4" />
-            {t("convertAnother")}
-          </button>
+          <div className="flex flex-col gap-2">
+            {file && outputFormat && (
+              <button
+                onClick={handleConvert}
+                className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
+              >
+                <RotateCcw className="h-4 w-4" />
+                {t("retry")}
+              </button>
+            )}
+            <button
+              onClick={handleReset}
+              className="inline-flex items-center justify-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <RefreshCw className="h-4 w-4" />
+              {t("convertAnother")}
+            </button>
+          </div>
         </div>
       )}
 

--- a/apps/web/src/components/file-dropzone.tsx
+++ b/apps/web/src/components/file-dropzone.tsx
@@ -70,7 +70,7 @@ export function FileDropzone({ onFileSelect, disabled, remainingConversions }: F
     <div
       {...getRootProps()}
       className={cn(
-        "border-2 border-dashed rounded-xl p-12 text-center cursor-pointer transition-colors",
+        "border-2 border-dashed rounded-xl p-6 md:p-12 text-center cursor-pointer transition-colors",
         isDragActive
           ? "border-primary bg-accent"
           : "border-border hover:border-primary hover:bg-accent/50",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -47,7 +47,10 @@
     "contact": "Contact",
     "benefitFast": "Convert in seconds",
     "benefitNoSignup": "No signup required",
-    "benefitAutoDelete": "Auto-deleted in 24h"
+    "benefitAutoDelete": "Auto-deleted in 24h",
+    "retry": "Try Again",
+    "softUpsell": "Only {remaining} free conversion(s) left today.",
+    "softUpsellLink": "Get unlimited with Plus →"
   },
   "seo": {
     "homeTitle": "QuickConv - Free Online Image Converter | WebP AVIF HEIC",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -47,7 +47,10 @@
     "contact": "お問い合わせ",
     "benefitFast": "数秒で変換",
     "benefitNoSignup": "登録不要",
-    "benefitAutoDelete": "24時間で自動削除"
+    "benefitAutoDelete": "24時間で自動削除",
+    "retry": "もう一度試す",
+    "softUpsell": "本日の無料変換は残り{remaining}回です。",
+    "softUpsellLink": "Plusなら無制限 →"
   },
   "seo": {
     "homeTitle": "QuickConv - 無料オンライン画像変換 | WebP AVIF HEIC対応",


### PR DESCRIPTION
## Summary
- **#212 DL全幅化**: ダウンロードボタンを `w-full` に、完了アイコンを CheckCircle2 + zoom-in アニメーション
- **#213 リトライ**: エラー画面に RotateCcw リトライボタン追加（同ファイル・同フォーマットで再実行）
- **#214 モバイルパディング**: ドロップゾーン `p-12` → `p-6 md:p-12`（モバイルでの画面圧迫解消）
- **#216 ソフトアップセル**: 残り3回以下で変換ボタン横にインラインメッセージ「Plusなら無制限」

Closes #212
Closes #213
Closes #214
Closes #216

## Test plan
- [x] `pnpm build` 成功
- [x] `pnpm lint` パス
- [ ] モバイルでパディング縮小確認
- [ ] DLボタン全幅確認
- [ ] エラー時リトライ動作確認
- [ ] 残り3回以下でアップセル表示確認