### PR TITLE
feat(ux): 専用変換ページでドロップ即変換

### DIFF
--- a/apps/web/src/app/[locale]/convert/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/convert/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { Breadcrumb } from "@/components/breadcrumb";
 import { HowToJsonLd, BreadcrumbJsonLd, FAQJsonLd } from "@/components/json-ld";
 import { RelatedConversions } from "@/components/related-conversions";
 import { ConvertPageContent } from "@/components/convert-page-content";
-import { CONVERSION_PAIRS, getRelatedConversions } from "@quickconv/shared";
+import { CONVERSION_PAIRS, getRelatedConversions, type OutputFormat } from "@quickconv/shared";
 import { locales, type Locale } from "@/lib/i18n/config";
 import { buildPageMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
@@ -128,7 +128,7 @@ export default async function ConvertPage({ params }: PageProps) {
           })}
         </p>
       </div>
-      <ConversionCard />
+      <ConversionCard presetFormat={to as OutputFormat} />
       <ConvertPageContent from={from} to={to} />
       <RelatedConversions conversions={relatedConversions} />
       <FAQJsonLd faqItems={faqItems} />

--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -35,11 +35,15 @@ import type { OutputFormat } from "@quickconv/shared";
 /** Warning threshold: show warning when remaining <= this value */
 const REMAINING_WARNING_THRESHOLD = 3;
 
-export function ConversionCard() {
+interface ConversionCardProps {
+  presetFormat?: OutputFormat;
+}
+
+export function ConversionCard({ presetFormat }: ConversionCardProps = {}) {
   const t = useTranslations("common");
   const tp = useTranslations("preview");
   const [file, setFile] = useState<File | null>(null);
-  const [outputFormat, setOutputFormat] = useState<OutputFormat | null>(null);
+  const [outputFormat, setOutputFormat] = useState<OutputFormat | null>(presetFormat ?? null);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const { plan, isPaid } = useSubscription();
   const {
@@ -80,8 +84,19 @@ export function ConversionCard() {
 
   const handleFileSelect = (selectedFile: File) => {
     setFile(selectedFile);
-    setOutputFormat(null);
-    reset();
+    if (presetFormat) {
+      setOutputFormat(presetFormat);
+      reset();
+      // Auto-start conversion on preset pages
+      if (remainingConversions !== null && remainingConversions <= 0) {
+        setShowUpgradeModal(true);
+      } else {
+        startConversion(selectedFile, presetFormat);
+      }
+    } else {
+      setOutputFormat(null);
+      reset();
+    }
   };
 
   const handleConvert = () => {


### PR DESCRIPTION
## Summary
- ConversionCard に `presetFormat` プロップ追加
- /convert/heic-to-jpg 等の専用ページでは、slugから出力フォーマットが確定済みのため、ファイルドロップで即変換開始（フォーマット選択ステップをスキップ）
- レート制限到達時はアップグレードモーダルを表示

Closes #217

## Test plan
- [x] `pnpm build` 成功
- [ ] 専用ページでファイルドロップ後にフォーマット選択なしで変換開始
- [ ] ホームページでは従来通りフォーマット選択が必要
- [ ] レート制限時にモーダル表示