### PR TITLE
feat(ux): ファイルサイズ比較・実績カウンター・LCP改善

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,6 +23,7 @@ import account from "./routes/account";
 import resize from "./routes/resize";
 import stream from "./routes/stream";
 import presign from "./routes/presign";
+import stats from "./routes/stats";
 
 const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -83,5 +84,6 @@ app.route("/api/account", account);
 app.route("/api/resize", resize);
 app.route("/api/stream", stream);
 app.route("/api/upload", presign);
+app.route("/api/stats", stats);
 
 export default app;

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+import type { Env } from "../types/env";
+
+const stats = new Hono<{ Bindings: Env }>();
+
+stats.get("/", async (c) => {
+  const result = await c.env.DB.prepare(
+    "SELECT COUNT(*) as count FROM jobs WHERE status = 'completed'",
+  ).first<{ count: number }>();
+
+  return c.json({
+    totalConversions: result?.count ?? 0,
+  });
+});
+
+export default stats;

--- a/apps/api/src/routes/status.ts
+++ b/apps/api/src/routes/status.ts
@@ -17,6 +17,7 @@ status.get("/:jobId", async (c) => {
     status: job.status,
     progress: job.progress,
     downloadUrl: job.status === "completed" ? `/api/download/${job.id}` : undefined,
+    outputFileSize: job.status === "completed" ? (job.fileSize ?? undefined) : undefined,
     error: job.errorMessage || undefined,
   });
 });

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,8 +1,15 @@
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
+import { Inter } from "next/font/google";
 import { Toaster } from "sonner";
 import { routing } from "@/lib/i18n/routing";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+});
 import { locales } from "@/lib/i18n/config";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
@@ -38,7 +45,7 @@ export default async function LocaleLayout({
   const messages = await getMessages();
 
   return (
-    <html lang={locale}>
+    <html lang={locale} className={inter.variable}>
       <head>
         <meta
           name="keywords"

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { ConversionCard } from "@/components/conversion-card";
 import { PopularConversions } from "@/components/popular-conversions";
 import { HeroHeadline } from "@/components/hero-headline";
+import { ConversionCounter } from "@/components/conversion-counter";
 import { WebApplicationJsonLd } from "@/components/json-ld";
 import { buildPageMetadata } from "@/lib/metadata";
 import { locales, type Locale } from "@/lib/i18n/config";
@@ -49,6 +50,7 @@ export default async function HomePage({
         <p className="mt-3 text-lg text-muted-foreground">
           {t("description")}
         </p>
+        <ConversionCounter />
       </div>
       <ConversionCard />
       <PopularConversions />

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -10,7 +10,7 @@
   --color-border: #e5e5e5;
   --color-accent: #f0f7ff;
   --color-destructive: #ef4444;
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --radius: 0.5rem;
 }
 

--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -67,6 +67,7 @@ export function ConversionCard({ presetFormat }: ConversionCardProps = {}) {
     recommendations,
     recommendationComputing,
     conversionProgress,
+    outputFileSize,
   } = useConversion();
   const { trackFileDownload } = useGAEvent();
 
@@ -363,6 +364,11 @@ export function ConversionCard({ presetFormat }: ConversionCardProps = {}) {
           </div>
           <p className="font-medium text-green-600">{t("completed")}</p>
 
+          {/* File size comparison */}
+          {file && outputFileSize != null && (
+            <FileSizeComparison inputSize={file.size} outputSize={outputFileSize} />
+          )}
+
           {/* Show remaining count after conversion */}
           {hasRateLimitInfo && (
             <span
@@ -444,6 +450,30 @@ export function ConversionCard({ presetFormat }: ConversionCardProps = {}) {
           onClose={() => setShowUpgradeModal(false)}
           dailyLimit={dailyLimit}
         />
+      )}
+    </div>
+  );
+}
+
+function FileSizeComparison({ inputSize, outputSize }: { inputSize: number; outputSize: number }) {
+  const formatSize = (bytes: number) => {
+    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(bytes / 1024).toFixed(0)} KB`;
+  };
+
+  const reduction = Math.round((1 - outputSize / inputSize) * 100);
+  const increased = outputSize > inputSize;
+
+  return (
+    <div className="flex items-center justify-center gap-3 text-sm text-muted-foreground">
+      <span>{formatSize(inputSize)}</span>
+      <span className="text-foreground">→</span>
+      <span className="font-medium text-foreground">{formatSize(outputSize)}</span>
+      {!increased && reduction > 0 && (
+        <span className="text-green-600 font-medium">-{reduction}%</span>
+      )}
+      {increased && (
+        <span className="text-yellow-600 font-medium">+{Math.abs(reduction)}%</span>
       )}
     </div>
   );

--- a/apps/web/src/components/conversion-counter.tsx
+++ b/apps/web/src/components/conversion-counter.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { fetchStats } from "@/lib/api-client";
+
+export function ConversionCounter() {
+  const t = useTranslations("common");
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetchStats()
+      .then((stats) => setCount(stats.totalConversions))
+      .catch(() => {});
+  }, []);
+
+  if (count === null || count < 100) return null;
+
+  const formatted = count.toLocaleString();
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      {t("conversionCount", { count: formatted })}
+    </p>
+  );
+}

--- a/apps/web/src/components/hero-headline.tsx
+++ b/apps/web/src/components/hero-headline.tsx
@@ -14,6 +14,7 @@ const STORAGE_KEY = "hero_variant";
 export function HeroHeadline() {
   const t = useTranslations("common");
   const [variantIndex, setVariantIndex] = useState(0);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     const stored = sessionStorage.getItem(STORAGE_KEY);
@@ -24,9 +25,11 @@ export function HeroHeadline() {
       sessionStorage.setItem(STORAGE_KEY, String(idx));
       setVariantIndex(idx);
     }
+    setMounted(true);
   }, []);
 
-  const key = VARIANT_KEYS[variantIndex];
+  // SSR and initial render: always show variant1 (no layout shift)
+  const key = mounted ? VARIANT_KEYS[variantIndex] : VARIANT_KEYS[0];
 
   return (
     <h1 className="text-4xl font-bold tracking-tight" data-variant={key}>

--- a/apps/web/src/hooks/use-conversion.ts
+++ b/apps/web/src/hooks/use-conversion.ts
@@ -31,6 +31,7 @@ interface ConversionState {
   conversionProgress: number;
   jobId: string | null;
   downloadUrl: string | null;
+  outputFileSize: number | null;
   error: string | null;
 }
 
@@ -49,6 +50,7 @@ export function useConversion() {
     conversionProgress: 0,
     jobId: null,
     downloadUrl: null,
+    outputFileSize: null,
     error: null,
   });
   const [previewState, setPreviewState] = useState<PreviewState>({
@@ -98,6 +100,7 @@ export function useConversion() {
         conversionProgress: 0,
         jobId: null,
         downloadUrl: null,
+        outputFileSize: null,
         error: null,
       });
 
@@ -174,6 +177,7 @@ export function useConversion() {
       conversionProgress: 0,
       jobId: null,
       downloadUrl: null,
+      outputFileSize: null,
       error: null,
     });
     setPreviewState({ previews: [], selectedIndex: 0, originalSize: 0 });
@@ -181,7 +185,7 @@ export function useConversion() {
 
   const startConversion = useCallback(
     async (file: File, outputFormat: OutputFormat) => {
-      setState({ step: "uploading", uploadProgress: 0, conversionProgress: 0, jobId: null, downloadUrl: null, error: null });
+      setState({ step: "uploading", uploadProgress: 0, conversionProgress: 0, jobId: null, downloadUrl: null, outputFileSize: null, error: null });
 
       const inputFormat = file.name.split(".").pop()?.toLowerCase() || "unknown";
       formatsRef.current = { from: inputFormat, to: outputFormat };
@@ -223,6 +227,13 @@ export function useConversion() {
                 stopPolling();
                 const durationMs = Date.now() - startTimeRef.current;
                 trackConversionComplete(inputFormat, outputFormat, durationMs);
+                // Fetch file size from status endpoint
+                checkStatus(jobId).then((status) => {
+                  setState((s) => ({
+                    ...s,
+                    outputFileSize: status.outputFileSize ?? null,
+                  }));
+                }).catch(() => { /* ignore */ });
                 setState((s) => ({
                   ...s,
                   step: "completed",
@@ -267,6 +278,7 @@ export function useConversion() {
                   step: "completed",
                   conversionProgress: 100,
                   downloadUrl: getDownloadUrl(jobId),
+                  outputFileSize: status.outputFileSize ?? null,
                 }));
               } else if (status.status === "failed") {
                 stopPolling();
@@ -314,7 +326,7 @@ export function useConversion() {
 
   const reset = useCallback(() => {
     stopPolling();
-    setState({ step: "idle", uploadProgress: 0, conversionProgress: 0, jobId: null, downloadUrl: null, error: null });
+    setState({ step: "idle", uploadProgress: 0, conversionProgress: 0, jobId: null, downloadUrl: null, outputFileSize: null, error: null });
     setPreviewState({ previews: [], selectedIndex: 0, originalSize: 0 });
     fileRef.current = null;
     outputFormatRef.current = null;

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -98,6 +98,12 @@ export async function checkStatus(jobId: string): Promise<StatusResponse> {
   return res.json();
 }
 
+export async function fetchStats(): Promise<{ totalConversions: number }> {
+  const res = await fetch(`${API_URL}/api/stats`);
+  if (!res.ok) return { totalConversions: 0 };
+  return res.json();
+}
+
 export function getDownloadUrl(jobId: string): string {
   return `${API_URL}/api/download/${jobId}`;
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -50,7 +50,8 @@
     "benefitAutoDelete": "Auto-deleted in 24h",
     "retry": "Try Again",
     "softUpsell": "Only {remaining} free conversion(s) left today.",
-    "softUpsellLink": "Get unlimited with Plus →"
+    "softUpsellLink": "Get unlimited with Plus →",
+    "conversionCount": "{count}+ files converted"
   },
   "seo": {
     "homeTitle": "QuickConv - Free Online Image Converter | WebP AVIF HEIC",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -50,7 +50,8 @@
     "benefitAutoDelete": "24時間で自動削除",
     "retry": "もう一度試す",
     "softUpsell": "本日の無料変換は残り{remaining}回です。",
-    "softUpsellLink": "Plusなら無制限 →"
+    "softUpsellLink": "Plusなら無制限 →",
+    "conversionCount": "{count}件以上のファイルを変換済み"
   },
   "seo": {
     "homeTitle": "QuickConv - 無料オンライン画像変換 | WebP AVIF HEIC対応",

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -22,6 +22,7 @@ export interface StatusResponse {
   status: JobStatus;
   progress?: number;
   downloadUrl?: string;
+  outputFileSize?: number;
   error?: string;
 }
 


### PR DESCRIPTION
## Summary
- **#218 ファイルサイズ比較**: StatusResponse に `outputFileSize` 追加、完了画面で変換前後サイズ+削減率(%)表示
- **#215 変換実績カウンター**: `/api/stats` エンドポイント新設（D1 completed job数）、トップページにカウンター表示（100件未満は非表示）
- **#219 LCP改善**: `next/font/google` で Inter フォント最適化（display:swap, CSS変数連携）、HeroHeadline SSR時にデフォルトテキスト即表示（CLS排除）

Closes #215
Closes #218
Closes #219

## Test plan
- [x] `pnpm --filter @quickconv/web build` 成功
- [x] `pnpm --filter @quickconv/api build` 成功
- [ ] 変換完了後にファイルサイズ比較が表示される
- [ ] /api/stats が totalConversions を返す
- [ ] フォント読み込みが最適化されている（DevTools Network確認）
- [ ] LCP Good率改善（CF Web Analytics で確認）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ホームページにファイル変換数の統計情報を表示する機能を追加しました。
  * 変換完了時に、入出力ファイルのサイズ比較表示（削減率/増加率付き）を追加しました。

* **スタイル**
  * Interフォントの実装を改善しました。

* **多言語対応**
  * 英語と日本語の翻訳メッセージを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->