### PR TITLE
docs: Issue完了サイクルに本番デプロイ/動作確認チェックリスト追加 (#288)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,17 +14,26 @@
 ```
 1. Issue着手 → gh issue edit <N> --add-label in-progress
 2. テスト作成（TDD） → E2Eテストを先に書く
-3. 実装
-4. ローカルビルド・テスト確認（pnpm build && vitest）
-5. Push → CI自動実行（lint/build/test）
+3. 実装（D1スキーマ変更時は apps/api/migrations/ にマイグレーション追加）
+4. ローカルビルド・テスト確認（pnpm build && pnpm test）
+5. Push → CI自動実行（lint / build / test / staging deploy）
 6. PR作成（Closes #XX 必須）
-7. ステージングE2E確認 → E2E_TARGET=staging npx playwright test --project=production
-8. PRマージ
-9. 本番デプロイ（CI自動 or 手動）
-10. 本番E2E確認 → E2E_TARGET=production npx playwright test --project=production
-11. 全PASS → Issue完了
+7. コードレビュー対応 → レビューコメントに全件返信
+8. ステージングE2E確認（CI e2e-stg ジョブ）→ PASSで本番デプロイを許可
+9. PRマージ
+10. 本番デプロイ:
+   a. D1マイグレーション（スキーマ変更時のみ）: `npx wrangler d1 migrations apply quickconv-db --remote`
+   b. Web（Pages）: CI自動デプロイ → 完了待ち
+   c. API（Workers）: CI自動デプロイ → 完了待ち
+   d. Converter（Cloud Run）: 変更時のみ手動 `gcloud builds submit --config=cloudbuild.yaml .`
+11. 本番動作確認:
+   a. ヘルスチェック: `curl https://api.quickconv.cc/health`
+   b. 変更箇所の手動確認（ブラウザ or curl）
+   c. 本番E2E確認（CI e2e-prod ジョブ、または手動 `E2E_TARGET=production npx playwright test --project=production`）
+12. 全PASS → Issue完了
 ```
-**ステップ7と10のE2E全PASSが受け入れ基準。スキップ不可。**
+**ステップ8（staging E2E）と 11c（production E2E）の全PASSが受け入れ基準。スキップ不可。**
+**D1スキーマ変更時は 10a を先に適用。テーブル不整合による 500 を防ぐため。**
 
 ## 開発ルール
 - **テストファースト必須**: 新機能・バグ修正は必ずテストから作成する。実装するたびにテストを増やす

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,15 @@
 ```
 1. Issue着手 → gh issue edit <N> --add-label in-progress
 2. テスト作成（TDD） → E2Eテストを先に書く
-3. 実装（D1スキーマ変更時は apps/api/migrations/ にマイグレーション追加）
-4. ローカルビルド・テスト確認（pnpm build && pnpm test）
+3. 実装（D1スキーマ変更時は apps/api/src/db/migrations/ にマイグレーション追加）
+4. ローカルビルド・テスト確認（`pnpm build && cd apps/api && pnpm test` — 現状 test スクリプトは apps/api のみ）
 5. Push → CI自動実行（lint / build / test / staging deploy）
 6. PR作成（Closes #XX 必須）
 7. コードレビュー対応 → レビューコメントに全件返信
 8. ステージングE2E確認（CI e2e-stg ジョブ）→ PASSで本番デプロイを許可
 9. PRマージ
 10. 本番デプロイ:
-   a. D1マイグレーション（スキーマ変更時のみ）: `npx wrangler d1 migrations apply quickconv-db --remote`
+   a. D1マイグレーション（スキーマ変更時のみ）: `cd apps/api && npx wrangler d1 migrations apply quickconv-db --remote`
    b. Web（Pages）: CI自動デプロイ → 完了待ち
    c. API（Workers）: CI自動デプロイ → 完了待ち
    d. Converter（Cloud Run）: 変更時のみ手動 `gcloud builds submit --config=cloudbuild.yaml .`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,6 +46,8 @@ gcloud builds submit --config=cloudbuild.yaml .
 **CI は D1 マイグレーションを適用しない。** スキーマ変更を含む PR をマージしたら、**本番デプロイ前** に必ず手動で適用する:
 
 ```bash
+cd apps/api
+
 # dry-run（適用内容を確認）
 npx wrangler d1 migrations list quickconv-db --remote
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -13,15 +13,59 @@ npx turbo build --filter=@quickconv/api       # APIのみ
 ```
 
 ## デプロイ（本番）
+
+### 通常フロー（CIに任せる）
+
+`main` への push で `.github/workflows/ci.yml` が以下を自動実行する:
+
+1. `lint-and-build` / `test`
+2. `deploy-stg` — Pages + Workers をステージングにデプロイ
+3. `e2e-stg` — ステージング E2E（失敗すると本番デプロイをブロック）
+4. `deploy-prod` — Pages + Workers を本番にデプロイ
+5. `e2e-prod` — 本番 E2E スモーク
+6. `notify` — 失敗時 Pushover 通知
+
+通常のマージでは下記コマンドを手動実行する必要はない。
+
+### 手動デプロイ（CIが落ちた / 緊急時のみ）
+
 ```bash
 # API (Cloudflare Workers)
-npx wrangler deploy --config apps/api/wrangler.toml
+cd apps/api && npx wrangler deploy
 
 # Frontend (Cloudflare Pages)
+npx turbo build --filter=@quickconv/web
 npx wrangler pages deploy apps/web/out --project-name quickconv-web
 
-# Converter (GCP Cloud Run)
+# Converter (GCP Cloud Run) — CI対象外、変更時のみ手動
 gcloud builds submit --config=cloudbuild.yaml .
+```
+
+### D1 マイグレーション（本番）
+
+**CI は D1 マイグレーションを適用しない。** スキーマ変更を含む PR をマージしたら、**本番デプロイ前** に必ず手動で適用する:
+
+```bash
+# dry-run（適用内容を確認）
+npx wrangler d1 migrations list quickconv-db --remote
+
+# 本番適用
+npx wrangler d1 migrations apply quickconv-db --remote
+```
+
+マイグレーション適用を忘れると `deploy-prod` 後の API で 500（テーブル不整合）が発生する。
+
+### デプロイ後の動作確認
+
+```bash
+# ヘルスチェック
+curl https://api.quickconv.cc/health
+
+# 本番 E2E スモーク（CIが e2e-prod で自動実行するが、手動再実行する場合）
+cd apps/web
+E2E_TARGET=production E2E_BASE_URL=https://quickconv.cc \
+  npx playwright test --project=production \
+  e2e/deploy-check.spec.ts e2e/smoke.spec.ts
 ```
 
 ## ステージング環境


### PR DESCRIPTION
## Summary
- CLAUDE.md の Issue完了サイクルを 11→12 ステップに拡張し、本番デプロイ（10a-d）と本番動作確認（11a-c）をサブステップ化
- D1マイグレーションの手動適用（スキーマ変更時のみ）と Converter（Cloud Run）の手動条件を明示
- docs/deploy.md を CI 自動フロー説明 + 手動コマンド（緊急時）+ D1マイグレーション + デプロイ後ヘルスチェック に再編
- 現状の CI（staging-gate + Workers/Pages 自動デプロイ, #291 実装済み）と整合させる形で Issue #288 の「API手動デプロイ」前提を現実に更新

## Test plan
- [x] CLAUDE.md に D1マイグレーション・本番動作確認・サブステップが含まれる（grep で確認）
- [x] docs/deploy.md に `wrangler d1 migrations apply quickconv-db --remote` と CI 自動フロー説明が含まれる
- [ ] ドキュメントのみの変更のためコード CI は lint/build/test が PASS すれば OK
- [ ] マージ後、本件の手順に従った次 Issue でサイクルが機能することを確認

Closes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * デプロイ手順とCIワークフローを拡張・明文化しました（stagingデプロイ、staging/prod E2EのCI実行、productionデプロイ手順、ヘルスチェック、手動E2E手順の追記）。
  * 本番前のスキーママイグレーション適用手順と注意事項を追加しました。
  * ローカル／CIでのテスト実行フローを明示しました。

* **Chores**
  * Issue完了サイクルと受け入れ基準（staging・production E2EのPASS必須）を更新しました。
  * PR審査フローでレビューコメントへの応答を必須化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->