### PR TITLE
fix(e2e): test-auth に upsertUser 追加で staging 認証を成立させる

### DIFF
--- a/apps/api/src/__tests__/test-auth-route.test.ts
+++ b/apps/api/src/__tests__/test-auth-route.test.ts
@@ -5,16 +5,11 @@ vi.mock("../services/auth", () => ({
 }));
 
 vi.mock("../repositories/user-repository", () => ({
-  upsertUser: vi.fn().mockResolvedValue({
-    email: "e2e@example.com",
-    stripeCustomerId: "id",
-    plan: "free",
-    googleId: "e2e-test-e2e@example.com",
-  }),
+  upsertE2ETestUser: vi.fn().mockResolvedValue(undefined),
 }));
 
 import testAuth from "../routes/test-auth";
-import { upsertUser } from "../repositories/user-repository";
+import { upsertE2ETestUser } from "../repositories/user-repository";
 import { createJwt } from "../services/auth";
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../types/env";
@@ -50,7 +45,7 @@ describe("POST /api/test/token", () => {
       { ...baseEnv, E2E_TEST_SECRET: undefined } as unknown as Env
     );
     expect(res.status).toBe(404);
-    expect(upsertUser).not.toHaveBeenCalled();
+    expect(upsertE2ETestUser).not.toHaveBeenCalled();
   });
 
   it("X-E2E-Secret 不一致 → 401", async () => {
@@ -65,7 +60,7 @@ describe("POST /api/test/token", () => {
       baseEnv
     );
     expect(res.status).toBe(401);
-    expect(upsertUser).not.toHaveBeenCalled();
+    expect(upsertE2ETestUser).not.toHaveBeenCalled();
   });
 
   it("email 未指定 → 400", async () => {
@@ -80,17 +75,17 @@ describe("POST /api/test/token", () => {
       baseEnv
     );
     expect(res.status).toBe(400);
-    expect(upsertUser).not.toHaveBeenCalled();
+    expect(upsertE2ETestUser).not.toHaveBeenCalled();
   });
 
-  it("正常系 → upsertUser を呼んでから JWT を発行する", async () => {
+  it("正常系（free）→ email を正規化し、upsertE2ETestUser → JWT の順で処理する", async () => {
     const app = createApp();
     const res = await app.request(
       "/api/test/token",
       {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-E2E-Secret": "e2e-secret" },
-        body: JSON.stringify({ email: "e2e@example.com", plan: "free" }),
+        body: JSON.stringify({ email: "  E2E@Example.COM  ", plan: "free" }),
       },
       baseEnv
     );
@@ -98,21 +93,51 @@ describe("POST /api/test/token", () => {
     const body = (await res.json()) as { token: string };
     expect(body.token).toBe("mock.jwt.token");
 
-    // upsertUser が JWT 発行前に呼ばれ、googleId が決定論的であること
-    expect(upsertUser).toHaveBeenCalledTimes(1);
-    expect(upsertUser).toHaveBeenCalledWith(
-      baseEnv.DB,
-      "e2e@example.com",
-      "e2e-test-e2e@example.com",
-      "E2E Test User"
-    );
+    expect(upsertE2ETestUser).toHaveBeenCalledTimes(1);
+    expect(upsertE2ETestUser).toHaveBeenCalledWith(baseEnv.DB, "e2e@example.com", "free");
     expect(createJwt).toHaveBeenCalledTimes(1);
+    expect(createJwt).toHaveBeenCalledWith(
+      { email: "e2e@example.com", plan: "free", name: "E2E Test User", picture: "" },
+      "jwt-secret"
+    );
 
-    // 呼び出し順: upsertUser → createJwt
-    const upsertCall = (upsertUser as unknown as { mock: { invocationCallOrder: number[] } }).mock
-      .invocationCallOrder[0];
-    const createJwtCall = (createJwt as unknown as { mock: { invocationCallOrder: number[] } }).mock
-      .invocationCallOrder[0];
+    // 呼び出し順: upsertE2ETestUser → createJwt
+    const upsertCall = vi.mocked(upsertE2ETestUser).mock.invocationCallOrder[0];
+    const createJwtCall = vi.mocked(createJwt).mock.invocationCallOrder[0];
     expect(upsertCall).toBeLessThan(createJwtCall);
+  });
+
+  it("plan 指定あり → upsertE2ETestUser と JWT 両方に反映される", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/api/test/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-E2E-Secret": "e2e-secret" },
+        body: JSON.stringify({ email: "plus@example.com", plan: "plus_monthly" }),
+      },
+      baseEnv
+    );
+    expect(res.status).toBe(200);
+    expect(upsertE2ETestUser).toHaveBeenCalledWith(baseEnv.DB, "plus@example.com", "plus_monthly");
+    expect(vi.mocked(createJwt).mock.calls[0][0]).toMatchObject({
+      email: "plus@example.com",
+      plan: "plus_monthly",
+    });
+  });
+
+  it("plan 未指定 → デフォルト 'free' で upsertE2ETestUser される", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/api/test/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-E2E-Secret": "e2e-secret" },
+        body: JSON.stringify({ email: "default@example.com" }),
+      },
+      baseEnv
+    );
+    expect(res.status).toBe(200);
+    expect(upsertE2ETestUser).toHaveBeenCalledWith(baseEnv.DB, "default@example.com", "free");
   });
 });

--- a/apps/api/src/__tests__/test-auth-route.test.ts
+++ b/apps/api/src/__tests__/test-auth-route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../services/auth", () => ({
+  createJwt: vi.fn().mockResolvedValue("mock.jwt.token"),
+}));
+
+vi.mock("../repositories/user-repository", () => ({
+  upsertUser: vi.fn().mockResolvedValue({
+    email: "e2e@example.com",
+    stripeCustomerId: "id",
+    plan: "free",
+    googleId: "e2e-test-e2e@example.com",
+  }),
+}));
+
+import testAuth from "../routes/test-auth";
+import { upsertUser } from "../repositories/user-repository";
+import { createJwt } from "../services/auth";
+import { Hono } from "hono";
+import type { Env, AppVariables } from "../types/env";
+
+type HonoEnv = { Bindings: Env; Variables: AppVariables };
+
+function createApp() {
+  const app = new Hono<HonoEnv>();
+  app.route("/api/test", testAuth);
+  return app;
+}
+
+const baseEnv = {
+  E2E_TEST_SECRET: "e2e-secret",
+  JWT_SECRET: "jwt-secret",
+  DB: {} as unknown as D1Database,
+} as unknown as Env;
+
+describe("POST /api/test/token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("E2E_TEST_SECRET 未設定 → 404", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/api/test/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-E2E-Secret": "x" },
+        body: JSON.stringify({ email: "e2e@example.com" }),
+      },
+      { ...baseEnv, E2E_TEST_SECRET: undefined } as unknown as Env
+    );
+    expect(res.status).toBe(404);
+    expect(upsertUser).not.toHaveBeenCalled();
+  });
+
+  it("X-E2E-Secret 不一致 → 401", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/api/test/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-E2E-Secret": "wrong" },
+        body: JSON.stringify({ email: "e2e@example.com" }),
+      },
+      baseEnv
+    );
+    expect(res.status).toBe(401);
+    expect(upsertUser).not.toHaveBeenCalled();
+  });
+
+  it("email 未指定 → 400", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/api/test/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-E2E-Secret": "e2e-secret" },
+        body: JSON.stringify({}),
+      },
+      baseEnv
+    );
+    expect(res.status).toBe(400);
+    expect(upsertUser).not.toHaveBeenCalled();
+  });
+
+  it("正常系 → upsertUser を呼んでから JWT を発行する", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/api/test/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-E2E-Secret": "e2e-secret" },
+        body: JSON.stringify({ email: "e2e@example.com", plan: "free" }),
+      },
+      baseEnv
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    expect(body.token).toBe("mock.jwt.token");
+
+    // upsertUser が JWT 発行前に呼ばれ、googleId が決定論的であること
+    expect(upsertUser).toHaveBeenCalledTimes(1);
+    expect(upsertUser).toHaveBeenCalledWith(
+      baseEnv.DB,
+      "e2e@example.com",
+      "e2e-test-e2e@example.com",
+      "E2E Test User"
+    );
+    expect(createJwt).toHaveBeenCalledTimes(1);
+
+    // 呼び出し順: upsertUser → createJwt
+    const upsertCall = (upsertUser as unknown as { mock: { invocationCallOrder: number[] } }).mock
+      .invocationCallOrder[0];
+    const createJwtCall = (createJwt as unknown as { mock: { invocationCallOrder: number[] } }).mock
+      .invocationCallOrder[0];
+    expect(upsertCall).toBeLessThan(createJwtCall);
+  });
+});

--- a/apps/api/src/__tests__/user-repository.test.ts
+++ b/apps/api/src/__tests__/user-repository.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { upsertE2ETestUser } from "../repositories/user-repository";
+
+function createMockDb() {
+  const first = vi.fn();
+  const run = vi.fn().mockResolvedValue({ success: true });
+  const bind = vi.fn(() => ({ first, run }));
+  const prepare = vi.fn(() => ({ bind }));
+  return { prepare, bind, first, run } as unknown as D1Database & {
+    first: ReturnType<typeof vi.fn>;
+    run: ReturnType<typeof vi.fn>;
+    bind: ReturnType<typeof vi.fn>;
+    prepare: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("upsertE2ETestUser", () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+  });
+
+  it("既存行あり → plan と updated_at を UPDATE（google_id は触らない）", async () => {
+    db.first.mockResolvedValue({ stripe_customer_id: "existing-id" });
+
+    await upsertE2ETestUser(db, "existing@example.com", "plus_monthly");
+
+    // SELECT + UPDATE の2クエリ
+    expect(db.prepare).toHaveBeenCalledTimes(2);
+    const selectSql = db.prepare.mock.calls[0][0];
+    const updateSql = db.prepare.mock.calls[1][0];
+    expect(selectSql).toContain("SELECT stripe_customer_id FROM users WHERE email = ?");
+    expect(updateSql).toContain("UPDATE users SET plan = ?");
+    expect(updateSql).not.toContain("google_id");
+
+    // UPDATE の bind 引数 (plan, email)
+    expect(db.bind).toHaveBeenLastCalledWith("plus_monthly", "existing@example.com");
+  });
+
+  it("既存行なし → 決定論的 googleId で INSERT する", async () => {
+    db.first.mockResolvedValue(null);
+
+    await upsertE2ETestUser(db, "new@example.com", "free");
+
+    // SELECT + INSERT
+    expect(db.prepare).toHaveBeenCalledTimes(2);
+    const insertSql = db.prepare.mock.calls[1][0];
+    expect(insertSql).toContain("INSERT INTO users");
+    expect(insertSql).toContain("google_id");
+
+    // INSERT の bind 引数: (id, email, googleId, plan)
+    const insertBind = db.bind.mock.calls[1];
+    expect(insertBind[1]).toBe("new@example.com");
+    expect(insertBind[2]).toBe("e2e-test:new@example.com");
+    expect(insertBind[3]).toBe("free");
+  });
+
+  it("既存行の google_id を上書きしない（real user 保護）", async () => {
+    db.first.mockResolvedValue({ stripe_customer_id: "real-customer-id" });
+
+    await upsertE2ETestUser(db, "real@example.com", "pro_monthly");
+
+    const updateSql = db.prepare.mock.calls[1][0];
+    expect(updateSql).not.toContain("google_id");
+    expect(db.bind).toHaveBeenLastCalledWith("pro_monthly", "real@example.com");
+  });
+});

--- a/apps/api/src/repositories/user-repository.ts
+++ b/apps/api/src/repositories/user-repository.ts
@@ -43,6 +43,41 @@ export async function upsertUser(
   };
 }
 
+/**
+ * E2E テスト用の user upsert。
+ * 既存行があれば plan / updated_at のみ更新（google_id は保持 = real user 行を壊さない）。
+ * 新規の場合は決定論的 googleId で INSERT する。
+ * email UNIQUE 制約での flake を防ぐため、SELECT は email で行う。
+ */
+export async function upsertE2ETestUser(
+  db: D1Database,
+  email: string,
+  plan: string
+): Promise<void> {
+  const existing = await db
+    .prepare("SELECT stripe_customer_id FROM users WHERE email = ?")
+    .bind(email)
+    .first();
+
+  if (existing) {
+    await db
+      .prepare("UPDATE users SET plan = ?, updated_at = datetime('now') WHERE email = ?")
+      .bind(plan, email)
+      .run();
+    return;
+  }
+
+  const id = crypto.randomUUID();
+  const googleId = `e2e-test:${email}`;
+  await db
+    .prepare(
+      `INSERT INTO users (stripe_customer_id, email, auth_provider, google_id, plan)
+       VALUES (?, ?, 'google', ?, ?)`
+    )
+    .bind(id, email, googleId, plan)
+    .run();
+}
+
 export async function getUserByEmail(
   db: D1Database,
   email: string

--- a/apps/api/src/routes/test-auth.ts
+++ b/apps/api/src/routes/test-auth.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../types/env";
 import { createJwt } from "../services/auth";
+import { upsertUser } from "../repositories/user-repository";
 
 /**
  * E2E テスト専用の JWT 発行エンドポイント。
@@ -23,6 +24,10 @@ testAuth.post("/token", async (c) => {
   if (!body?.email) {
     return c.json({ error: "email_required" }, 400);
   }
+
+  // optionalAuthMiddleware は DB にレコードが存在する email しか認証済みにしないため
+  // JWT 発行前に user を upsert しておく（決定論的な googleId `e2e-test-<email>` を使用）
+  await upsertUser(c.env.DB, body.email, `e2e-test-${body.email}`, "E2E Test User");
 
   const jwt = await createJwt(
     { email: body.email, plan: body.plan || "free", name: "E2E Test User", picture: "" },

--- a/apps/api/src/routes/test-auth.ts
+++ b/apps/api/src/routes/test-auth.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../types/env";
 import { createJwt } from "../services/auth";
-import { upsertUser } from "../repositories/user-repository";
+import { upsertE2ETestUser } from "../repositories/user-repository";
 
 /**
  * E2E テスト専用の JWT 発行エンドポイント。
@@ -25,12 +25,17 @@ testAuth.post("/token", async (c) => {
     return c.json({ error: "email_required" }, 400);
   }
 
-  // optionalAuthMiddleware は DB にレコードが存在する email しか認証済みにしないため
-  // JWT 発行前に user を upsert しておく（決定論的な googleId `e2e-test-<email>` を使用）
-  await upsertUser(c.env.DB, body.email, `e2e-test-${body.email}`, "E2E Test User");
+  // email を正規化して下流の比較と一致させる（DB / JWT 両方で同一値を使用）
+  const email = body.email.trim().toLowerCase();
+  const plan = body.plan || "free";
+
+  // optionalAuthMiddleware は DB 照合で user を解決するため、JWT 発行前に upsert する。
+  // plan を DB 側にも反映させるため upsertE2ETestUser を使う
+  // （/api/auth/me は DB の plan を返す）。
+  await upsertE2ETestUser(c.env.DB, email, plan);
 
   const jwt = await createJwt(
-    { email: body.email, plan: body.plan || "free", name: "E2E Test User", picture: "" },
+    { email, plan, name: "E2E Test User", picture: "" },
     c.env.JWT_SECRET
   );
 


### PR DESCRIPTION
## Summary
staging CI e2e-stg が 2週間連続で失敗していた根本原因を修正。

- trace 解析で「始める」ボタン → accounts.google.com に遷移していた
- useAuth → /api/auth/me → optionalAuthMiddleware が **D1 に該当 email の users 行がないと c.set("user", null)** で authenticated: false を返していた
- `/api/test/token` が JWT 発行のみで upsert していなかったのが元凶
- 修正: JWT 発行前に `upsertUser(DB, email, "e2e-test-<email>", "E2E Test User")` を実行

## 根本原因ファイル
- apps/api/src/middleware/auth.ts:25-28（DB 照合失敗で null）
- apps/api/src/routes/test-auth.ts（upsert なし）

## Test plan
- [x] 新規 unit test（src/__tests__/test-auth-route.test.ts）4 件追加
  - 404 / 401 / 400 / 200 正常系
  - upsertUser → createJwt の呼び出し順
  - googleId の決定論性（`e2e-test-<email>`）
- [x] `cd apps/api && pnpm test` で 11 files / 112 tests PASS
- [ ] マージ後の CI e2e-stg が Stripe Checkout へ正常遷移し PASS することを確認
- [ ] 本番は E2E_TEST_SECRET 未設定のため影響なし（endpoint 自体が 404 を返す）

## 本番影響
なし。`/api/test/token` は `E2E_TEST_SECRET` が未設定だと 404 を返す設計。本番に secret を設定しない運用を前提。

Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 認証エンドポイントの包括的なテストカバレッジを追加しました。複数のシナリオ（認証情報の検証、リクエストバリデーション、正常系パス）をカバーしています。
  * 認証フローでユーザーデータの自動登録機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->