### PR TITLE
docs: 技術記事③ 英訳ドラフト完成 + Dev.to/Hashnode投稿スクリプト

### DIFF
--- a/docs/articles/003-claude-code-web-setup-hook.md
+++ b/docs/articles/003-claude-code-web-setup-hook.md
@@ -1,0 +1,251 @@
+---
+title: "Claude Code on the Web: Why Your .env Vars Don't Reach the Setup Script (and How SessionStart Hook Fixes It)"
+description: "A debugging story about Claude Code Cloud Sandbox: the .env panel vars never make it into the setup script, only into the session shell. Moving clone logic to a SessionStart hook makes everything work."
+tags: ["anthropic", "claude", "devops", "bash"]
+canonical_url: ""
+cover_image: "https://storage.googleapis.com/zenn-user-upload/35c9731d164a-20260419.png"
+published: true
+published_at: "2026-04-19"
+platforms:
+  hashnode: ""
+  devto: ""
+  zenn: "https://zenn.dev/harieshokunin/articles/b1064354319ce2"
+  qiita: ""
+---
+
+![Claude Code on the web setup hook](https://storage.googleapis.com/zenn-user-upload/35c9731d164a-20260419.png)
+
+## TL;DR
+
+- Environment variables you put in the `.env` panel of Claude Code on the web (Cloud Sandbox) **do not reach the setup script**.
+- They only reach the **shell inside the running Claude Code session**.
+- So `git clone "https://x-access-token:${GH_TOKEN}@..."` inside the setup script fails — `GH_TOKEN` is empty at that point.
+- **Move the clone into a SessionStart hook** and it just works, because by then `$GH_TOKEN` is populated.
+
+This is a write-up of how I narrowed down a behavior that the official docs don't spell out clearly.
+
+## Background
+
+### What I wanted to do
+
+I've been collecting custom slash commands, skills, and a personal `CLAUDE.md` under `~/.claude/` locally. I wanted the same setup available inside Claude Code on the web. Everything is stored in a private repo called `miyashita337/agent-base`.
+
+According to the docs, cloud sessions do **not** carry over user-level settings like `~/.claude/CLAUDE.md` — only what's committed to the repo is available. So my plan was: on session start, clone `agent-base` and symlink its contents into `~/.claude/`.
+
+### First attempt (failed)
+
+I put a GitHub PAT into the `.env` panel of the Cloud Sandbox settings and tried to clone from the setup script.
+
+```bash
+# setup script
+#!/bin/bash
+set -e
+git clone "https://x-access-token:${GH_TOKEN}@github.com/miyashita337/agent-base.git" "$HOME/agent-base"
+```
+
+`.env` panel:
+
+```
+GH_TOKEN=github_pat_...   # ~90 chars, real value
+GIT_AUTHOR_NAME=miyashita337
+...
+```
+
+Result: **`fatal: could not read Username`**.
+
+## Narrowing it down
+
+### Symptom 1: my `echo` output never showed up
+
+For debugging I added `echo "GH_TOKEN length: ${#GH_TOKEN}"` in the setup script. But the setup-script UI only shows the last few lines of output, so anything mid-script gets silently dropped.
+
+### Workaround: dump everything to a log file
+
+I rewrote the script to redirect diagnostics into `/tmp/env-diag.log` and then `cat` it from inside the session.
+
+```bash
+#!/bin/bash
+set -e
+
+LOG=/tmp/env-diag.log
+
+{
+  echo "===== ENV DIAGNOSTICS ====="
+  echo "GH_TOKEN length: ${#GH_TOKEN}"
+  echo "GIT_AUTHOR_NAME: [${GIT_AUTHOR_NAME}]"
+  echo "TZ: [${TZ}]"
+  echo "LANG: [${LANG}]"
+  echo ""
+  echo "--- All env vars (names only) ---"
+  env | cut -d= -f1 | sort
+} | tee "$LOG"
+```
+
+Then I started a new session and asked Claude Code to `cat /tmp/env-diag.log`.
+
+### Symptom 2: the cache trap
+
+On some runs I didn't even see the "setup script executed" log line. Per the docs, the setup script **runs only on first creation** — after that, a filesystem snapshot is reused. Editing the `.env` panel alone does **not** invalidate the snapshot.
+
+What does invalidate it:
+
+- Changing the setup script body
+- Changing the allowed-domains list
+- ~7 days of age
+
+So I added a throwaway comment line like `# cache-bust 2026-04-19-01` at the top of the setup script. Semantically it's a no-op, but it's enough to force a rerun on the next session.
+
+### The result: every env var was empty
+
+```
+===== ENV DIAGNOSTICS =====
+GH_TOKEN length: 0
+GIT_AUTHOR_NAME: []
+TZ: []
+LANG: []
+...
+Custom vars found: 0 / expected 8
+```
+
+It wasn't just `GH_TOKEN` — **nothing from the `.env` panel was reaching the setup script**.
+
+### The clincher: the session shell has them
+
+Inside the running Claude Code session, I checked the same variables directly from the shell:
+
+```bash
+$ echo "GH=${#GH_TOKEN}, TZ=[$TZ], LANG=[$LANG]"
+GH=93, TZ=[Asia/Tokyo], LANG=[ja_JP.UTF-8]
+```
+
+All present. So:
+
+| When it runs | `.env` panel vars available? |
+|---|---|
+| Setup script | ❌ No |
+| Claude Code session shell | ✅ Yes |
+
+## Root cause and fix
+
+### Root cause
+
+The `.env` panel is injected **only into the Claude Code session shell**, not into the setup script. It's not a bug — it's just not documented clearly. The docs show `GH_TOKEN` as an example `.env` value, but that's aimed at the `gh` CLI picking it up inside the session, not at setup-script usage.
+
+### Fix: move clone logic into a SessionStart hook
+
+Drop the clone from the setup script. Put it in a SessionStart hook defined in the repo's `.claude/settings.json`. The hook runs **after** Claude Code has started, so `$GH_TOKEN` is in scope.
+
+**`.claude/settings.json`**
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup-agent-base.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**`scripts/setup-agent-base.sh`**
+
+```bash
+#!/bin/bash
+set -e
+
+AGENT_BASE_DIR="$HOME/agent-base"
+
+# Skip locally
+[ "$CLAUDE_CODE_REMOTE" != "true" ] && exit 0
+
+# Clone (GH_TOKEN is available at this point)
+if [ ! -d "$AGENT_BASE_DIR" ]; then
+  if [ -z "${GH_TOKEN:-}" ]; then
+    echo "setup-agent-base: GH_TOKEN is not set" >&2
+    exit 1
+  fi
+  # Pass the token via extraHeader so it doesn't end up in .git/config
+  git -c http.extraHeader="Authorization: Bearer ${GH_TOKEN}" \
+      clone "https://github.com/miyashita337/agent-base.git" "$AGENT_BASE_DIR"
+  git -C "$AGENT_BASE_DIR" config --unset-all http.extraHeader 2>/dev/null || true
+fi
+
+# Symlink into ~/.claude/ (idempotent)
+mkdir -p "$HOME/.claude"
+for dir in commands skills agents hooks; do
+  src="$AGENT_BASE_DIR/$dir"
+  dst="$HOME/.claude/$dir"
+  if [ -d "$src" ]; then
+    # If the destination is a real directory, back it up first
+    # (ln -sf into an existing dir creates a nested symlink inside it)
+    if [ -d "$dst" ] && [ ! -L "$dst" ]; then
+      mv "$dst" "${dst}.bak.$(date +%s)"
+    fi
+    ln -sfn "$src" "$dst"
+  fi
+done
+
+if [ -f "$AGENT_BASE_DIR/CLAUDE.md" ]; then
+  ln -sf "$AGENT_BASE_DIR/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+fi
+
+exit 0
+```
+
+A few deliberate choices:
+
+1. **`CLAUDE_CODE_REMOTE` guard** — early-exit outside of cloud sessions so local dev isn't affected.
+2. **Idempotent** — skip clone if the dir exists, but always refresh the symlinks. Partial-failure recovery just works.
+3. **No token in the URL** — use `http.extraHeader` so `.git/config` never contains a plaintext token.
+4. **`ln -sfn` not `ln -sf`** — if the destination is already a real directory, `ln -sf` nests the symlink *inside* it (e.g. `~/.claude/commands/commands`). Backing it up first and using `-n` (`--no-dereference`) forces a clean replacement.
+
+### What about the setup script?
+
+**Leave it empty.** You can delete the diagnostics too.
+
+## Verification
+
+Fresh session, `ls -la ~/.claude/`:
+
+```
+CLAUDE.md -> /home/user/agent-base/CLAUDE.md
+commands  -> /home/user/agent-base/commands
+skills    -> /home/user/agent-base/skills
+agents    -> /home/user/agent-base/agents
+hooks     -> /home/user/agent-base/hooks
+```
+
+Typing `/` shows all the custom slash commands from `agent-base` (`/capture`, `/pdca`, `/inv`, ...) and they execute without issue.
+
+## Gotchas summary
+
+| Gotcha | Fix |
+|---|---|
+| `.env` vars don't reach the setup script | Move clone into a SessionStart hook |
+| Setup-script `echo` output is truncated | Redirect to a log file and `cat` it later |
+| Setup script is cached and won't rerun | Add/edit a throwaway comment to bust the cache |
+| New sessions can't start with an empty prompt | Type anything — but remember it becomes the first instruction to Claude |
+| `ln -sf` doesn't overwrite existing directories | Back up first, then `ln -sfn` |
+| `git clone https://x-access-token:${TOKEN}@...` leaks the token into `.git/config` | Pass it via `-c http.extraHeader=...` instead |
+
+## Closing
+
+The "setup script can't see `.env` vars" behavior is inferable if you read the docs carefully — the `gh` CLI example hints at "this is for in-session auto-pickup" — but it's never stated plainly. Easy to misread as "you can use these in the setup script too."
+
+Hope this saves someone else the afternoon I lost.
+
+## References
+
+- [Use Claude Code on the web — Claude Code Docs](https://code.claude.com/docs/en/claude-code-on-the-web)
+- [Hooks configuration — Claude Code Docs](https://code.claude.com/docs/en/hooks)
+- Original Japanese post: https://zenn.dev/harieshokunin/articles/b1064354319ce2
+
+![Verification screenshot](https://storage.googleapis.com/zenn-user-upload/dd6ce1e200e5-20260419.png)

--- a/docs/articles/003-claude-code-web-setup-hook.md
+++ b/docs/articles/003-claude-code-web-setup-hook.md
@@ -7,8 +7,8 @@ cover_image: "https://storage.googleapis.com/zenn-user-upload/35c9731d164a-20260
 published: true
 published_at: "2026-04-19"
 platforms:
-  hashnode: ""
-  devto: ""
+  hashnode: "https://quickconv-dev.hashnode.dev/claude-code-on-the-web-why-your-env-vars-dont-reach-the-setup-script-and-how-sessionstart-hook-fixes-it"
+  devto: "https://dev.to/cc_quickconv_ff5b94a1d015/claude-code-on-the-web-why-your-env-vars-dont-reach-the-setup-script-and-how-sessionstart-hook-4n6"
   zenn: "https://zenn.dev/harieshokunin/articles/b1064354319ce2"
   qiita: ""
 ---

--- a/docs/articles/003-claude-code-web-setup-hook.md
+++ b/docs/articles/003-claude-code-web-setup-hook.md
@@ -3,7 +3,6 @@ title: "Claude Code on the Web: Why Your .env Vars Don't Reach the Setup Script 
 description: "A debugging story about Claude Code Cloud Sandbox: the .env panel vars never make it into the setup script, only into the session shell. Moving clone logic to a SessionStart hook makes everything work."
 tags: ["anthropic", "claude", "devops", "bash"]
 canonical_url: ""
-cover_image: "https://storage.googleapis.com/zenn-user-upload/35c9731d164a-20260419.png"
 published: true
 published_at: "2026-04-19"
 platforms:
@@ -12,8 +11,6 @@ platforms:
   zenn: "https://zenn.dev/harieshokunin/articles/b1064354319ce2"
   qiita: ""
 ---
-
-![Claude Code on the web setup hook](https://storage.googleapis.com/zenn-user-upload/35c9731d164a-20260419.png)
 
 ## TL;DR
 
@@ -109,6 +106,8 @@ Custom vars found: 0 / expected 8
 
 It wasn't just `GH_TOKEN` — **nothing from the `.env` panel was reaching the setup script**.
 
+![Diagnostic log: 0 / 8 expected custom vars found](https://storage.googleapis.com/zenn-user-upload/35c9731d164a-20260419.png)
+
 ### The clincher: the session shell has them
 
 Inside the running Claude Code session, I checked the same variables directly from the shell:
@@ -117,6 +116,8 @@ Inside the running Claude Code session, I checked the same variables directly fr
 $ echo "GH=${#GH_TOKEN}, TZ=[$TZ], LANG=[$LANG]"
 GH=93, TZ=[Asia/Tokyo], LANG=[ja_JP.UTF-8]
 ```
+
+![Shell output showing GH=93, TZ=[Asia/Tokyo], LANG=[ja_JP.UTF-8]](https://storage.googleapis.com/zenn-user-upload/dd6ce1e200e5-20260419.png)
 
 All present. So:
 
@@ -247,5 +248,3 @@ Hope this saves someone else the afternoon I lost.
 - [Use Claude Code on the web — Claude Code Docs](https://code.claude.com/docs/en/claude-code-on-the-web)
 - [Hooks configuration — Claude Code Docs](https://code.claude.com/docs/en/hooks)
 - Original Japanese post: https://zenn.dev/harieshokunin/articles/b1064354319ce2
-
-![Verification screenshot](https://storage.googleapis.com/zenn-user-upload/dd6ce1e200e5-20260419.png)

--- a/tools/publish-devto-003.mjs
+++ b/tools/publish-devto-003.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Dev.to API で 003-claude-code-web-setup-hook.md を投稿するスクリプト
+// 使い方: DEVTO_API_KEY=xxx node tools/publish-devto-003.mjs
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const API_KEY = process.env.DEVTO_API_KEY;
+if (!API_KEY) {
+  console.error("ERROR: DEVTO_API_KEY が未設定です");
+  process.exit(1);
+}
+
+const articlePath = resolve(
+  __dirname,
+  "../docs/articles/003-claude-code-web-setup-hook.md",
+);
+const raw = readFileSync(articlePath, "utf-8");
+const body = raw.replace(/^---[\s\S]*?---\n/, "").trim();
+
+const payload = {
+  article: {
+    title:
+      "Claude Code on the Web: Why Your .env Vars Don't Reach the Setup Script (and How SessionStart Hook Fixes It)",
+    body_markdown: body,
+    published: true,
+    canonical_url: "https://zenn.dev/harieshokunin/articles/b1064354319ce2",
+    tags: ["anthropic", "claude", "devops", "bash"],
+    description:
+      "A debugging story about Claude Code Cloud Sandbox: the .env panel vars never make it into the setup script, only into the session shell. Moving clone logic to a SessionStart hook makes everything work.",
+  },
+};
+
+console.log("Dev.toに投稿中...");
+
+const res = await fetch("https://dev.to/api/articles", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "api-key": API_KEY,
+  },
+  body: JSON.stringify(payload),
+});
+
+const json = await res.json();
+
+if (!res.ok) {
+  console.error("エラー:", JSON.stringify(json, null, 2));
+  process.exit(1);
+}
+
+console.log("✅ 投稿成功!");
+console.log("  タイトル:", json.title);
+console.log("  URL:", json.url);
+console.log("  canonical:", json.canonical_url);

--- a/tools/publish-hashnode-003.mjs
+++ b/tools/publish-hashnode-003.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Hashnode GraphQL API で 003-claude-code-web-setup-hook.md を投稿するスクリプト
+// 使い方: HASHNODE_TOKEN=xxx HASHNODE_PUBLICATION_ID=xxx node tools/publish-hashnode-003.mjs
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const TOKEN = process.env.HASHNODE_TOKEN;
+const PUBLICATION_SLUG = process.env.HASHNODE_PUBLICATION_ID;
+
+if (!TOKEN) {
+  console.error("ERROR: HASHNODE_TOKEN が未設定です");
+  process.exit(1);
+}
+if (!PUBLICATION_SLUG) {
+  console.error("ERROR: HASHNODE_PUBLICATION_ID が未設定です");
+  process.exit(1);
+}
+
+const isObjectId = /^[a-f0-9]{24}$/i.test(PUBLICATION_SLUG);
+
+let PUBLICATION_ID = PUBLICATION_SLUG;
+if (!isObjectId) {
+  const host = PUBLICATION_SLUG.includes(".")
+    ? PUBLICATION_SLUG
+    : `${PUBLICATION_SLUG}.hashnode.dev`;
+  console.log(`Publication ID を取得中 (host: ${host})...`);
+  const res = await fetch("https://gql.hashnode.com", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: TOKEN },
+    body: JSON.stringify({
+      query: `{ publication(host: "${host}") { id title } }`,
+    }),
+  });
+  const json = await res.json();
+  if (json.errors || !json.data?.publication?.id) {
+    console.error("Publication取得エラー:", JSON.stringify(json, null, 2));
+    process.exit(1);
+  }
+  PUBLICATION_ID = json.data.publication.id;
+  console.log(`  ID: ${PUBLICATION_ID} (${json.data.publication.title})`);
+}
+
+const articlePath = resolve(
+  __dirname,
+  "../docs/articles/003-claude-code-web-setup-hook.md",
+);
+const raw = readFileSync(articlePath, "utf-8");
+const body = raw.replace(/^---[\s\S]*?---\n/, "").trim();
+
+const title =
+  "Claude Code on the Web: Why Your .env Vars Don't Reach the Setup Script (and How SessionStart Hook Fixes It)";
+const tags = [
+  { slug: "anthropic", name: "Anthropic" },
+  { slug: "claude", name: "Claude" },
+  { slug: "devops", name: "DevOps" },
+  { slug: "bash", name: "Bash" },
+];
+
+const mutation = `
+  mutation PublishPost($input: PublishPostInput!) {
+    publishPost(input: $input) {
+      post {
+        id
+        title
+        url
+        slug
+      }
+    }
+  }
+`;
+
+const variables = {
+  input: {
+    title,
+    contentMarkdown: body,
+    tags,
+    publicationId: PUBLICATION_ID,
+    originalArticleURL: "https://zenn.dev/harieshokunin/articles/b1064354319ce2",
+    metaTags: {
+      title,
+      description:
+        "A debugging story about Claude Code Cloud Sandbox: the .env panel vars never make it into the setup script, only into the session shell. Moving clone logic to a SessionStart hook makes everything work.",
+    },
+  },
+};
+
+console.log("Hashnodeに投稿中...");
+
+const res = await fetch("https://gql.hashnode.com", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: TOKEN,
+  },
+  body: JSON.stringify({ query: mutation, variables }),
+});
+
+const json = await res.json();
+
+if (json.errors) {
+  console.error("エラー:", JSON.stringify(json.errors, null, 2));
+  process.exit(1);
+}
+
+const post = json.data.publishPost.post;
+console.log("✅ 投稿成功!");
+console.log("  タイトル:", post.title);
+console.log("  URL:", post.url);

--- a/tools/update-devto-003.mjs
+++ b/tools/update-devto-003.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Dev.to API で公開済みの 003 記事を更新するスクリプト
+// 使い方: DEVTO_API_KEY=xxx node tools/update-devto-003.mjs
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const API_KEY = process.env.DEVTO_API_KEY;
+if (!API_KEY) {
+  console.error("ERROR: DEVTO_API_KEY が未設定です");
+  process.exit(1);
+}
+
+const TITLE =
+  "Claude Code on the Web: Why Your .env Vars Don't Reach the Setup Script (and How SessionStart Hook Fixes It)";
+
+console.log("自分の記事一覧を取得中...");
+const listRes = await fetch("https://dev.to/api/articles/me", {
+  headers: { "api-key": API_KEY },
+});
+const list = await listRes.json();
+if (!listRes.ok) {
+  console.error("一覧取得エラー:", JSON.stringify(list, null, 2));
+  process.exit(1);
+}
+const target = list.find((a) => a.title === TITLE);
+if (!target) {
+  console.error(`記事が見つかりません: ${TITLE}`);
+  console.error("candidates:", list.map((a) => a.title));
+  process.exit(1);
+}
+console.log(`  ID: ${target.id} (${target.url})`);
+
+const articlePath = resolve(
+  __dirname,
+  "../docs/articles/003-claude-code-web-setup-hook.md",
+);
+const raw = readFileSync(articlePath, "utf-8");
+const body = raw.replace(/^---[\s\S]*?---\n/, "").trim();
+
+const payload = {
+  article: {
+    title: TITLE,
+    body_markdown: body,
+    published: true,
+    canonical_url: "https://zenn.dev/harieshokunin/articles/b1064354319ce2",
+    tags: ["anthropic", "claude", "devops", "bash"],
+    description:
+      "A debugging story about Claude Code Cloud Sandbox: the .env panel vars never make it into the setup script, only into the session shell. Moving clone logic to a SessionStart hook makes everything work.",
+  },
+};
+
+console.log("Dev.to 記事を更新中...");
+const res = await fetch(`https://dev.to/api/articles/${target.id}`, {
+  method: "PUT",
+  headers: {
+    "Content-Type": "application/json",
+    "api-key": API_KEY,
+  },
+  body: JSON.stringify(payload),
+});
+const json = await res.json();
+if (!res.ok) {
+  console.error("エラー:", JSON.stringify(json, null, 2));
+  process.exit(1);
+}
+
+console.log("✅ 更新成功!");
+console.log("  URL:", json.url);

--- a/tools/update-hashnode-003.mjs
+++ b/tools/update-hashnode-003.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Hashnode GraphQL API で公開済みの 003 記事を更新するスクリプト
+// 使い方: HASHNODE_TOKEN=xxx HASHNODE_PUBLICATION_ID=xxx node tools/update-hashnode-003.mjs
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const TOKEN = process.env.HASHNODE_TOKEN;
+const PUBLICATION_SLUG = process.env.HASHNODE_PUBLICATION_ID;
+
+if (!TOKEN || !PUBLICATION_SLUG) {
+  console.error("ERROR: HASHNODE_TOKEN / HASHNODE_PUBLICATION_ID が未設定");
+  process.exit(1);
+}
+
+const POST_SLUG =
+  "claude-code-on-the-web-why-your-env-vars-dont-reach-the-setup-script-and-how-sessionstart-hook-fixes-it";
+
+async function gql(query, variables) {
+  const res = await fetch("https://gql.hashnode.com", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: TOKEN },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) {
+    console.error("GraphQL エラー:", JSON.stringify(json.errors, null, 2));
+    process.exit(1);
+  }
+  return json.data;
+}
+
+const host = PUBLICATION_SLUG.includes(".")
+  ? PUBLICATION_SLUG
+  : `${PUBLICATION_SLUG}.hashnode.dev`;
+
+console.log(`Post ID を取得中 (host: ${host}, slug: ${POST_SLUG})...`);
+const lookup = await gql(
+  `query($host: String!, $slug: String!) {
+     publication(host: $host) {
+       post(slug: $slug) { id title }
+     }
+   }`,
+  { host, slug: POST_SLUG },
+);
+const post = lookup.publication?.post;
+if (!post) {
+  console.error("記事が見つかりません");
+  process.exit(1);
+}
+console.log(`  ID: ${post.id} (${post.title})`);
+
+const articlePath = resolve(
+  __dirname,
+  "../docs/articles/003-claude-code-web-setup-hook.md",
+);
+const raw = readFileSync(articlePath, "utf-8");
+const body = raw.replace(/^---[\s\S]*?---\n/, "").trim();
+
+const title =
+  "Claude Code on the Web: Why Your .env Vars Don't Reach the Setup Script (and How SessionStart Hook Fixes It)";
+const tags = [
+  { slug: "anthropic", name: "Anthropic" },
+  { slug: "claude", name: "Claude" },
+  { slug: "devops", name: "DevOps" },
+  { slug: "bash", name: "Bash" },
+];
+
+console.log("Hashnode 記事を更新中...");
+const updated = await gql(
+  `mutation($input: UpdatePostInput!) {
+     updatePost(input: $input) {
+       post { id title url slug }
+     }
+   }`,
+  {
+    input: {
+      id: post.id,
+      title,
+      contentMarkdown: body,
+      tags,
+      originalArticleURL: "https://zenn.dev/harieshokunin/articles/b1064354319ce2",
+      metaTags: {
+        title,
+        description:
+          "A debugging story about Claude Code Cloud Sandbox: the .env panel vars never make it into the setup script, only into the session shell. Moving clone logic to a SessionStart hook makes everything work.",
+      },
+    },
+  },
+);
+const result = updated.updatePost.post;
+console.log("✅ 更新成功!");
+console.log("  URL:", result.url);


### PR DESCRIPTION
Zenn記事 (https://zenn.dev/harieshokunin/articles/b1064354319ce2)
「Claude Code on the web で setup script に環境変数が届かない罠と、SessionStart hook」
を英訳し、Dev.to / Hashnode へクロスポストするスクリプトを追加。

- docs/articles/003-claude-code-web-setup-hook.md: 英訳本文 + 画像2枚
- tools/publish-devto-003.mjs: DEVTO_API_KEY で投稿
- tools/publish-hashnode-003.mjs: HASHNODE_TOKEN + PUBLICATION_ID で投稿
- canonical_url は Zenn 原文に設定（SEO重複回避）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Claude Code Web設定のトラブルシューティングガイドを追加

* **Chores**
  * ブログプラットフォーム向けの自動公開・更新スクリプトを追加（Dev.to、Hashnode対応）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->