### PR TITLE
chore: tools/team_salary 編集ルーチンを CLAUDE.md に明文化 + bump ヘルパー追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,8 @@ gh pr create --repo miyashita337/team_salary --base main \
   --title "..." --body "..."
 
 # 3. PR merge 後、convert-service 側で submodule pointer を bump
-cd "$(git rev-parse --show-toplevel)"
-bash scripts/bump-team-salary.sh           # submodule update --remote + commit
+cd ../..                                   # tools/team_salary から convert-service ルートへ戻る
+bash scripts/bump-team-salary.sh           # submodule update --init --remote + commit
 # 必要なら convert-service 側も PR 化して push
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,31 @@ pnpm dev          # ローカル開発
 pnpm build        # 全パッケージビルド
 ```
 
+## tools/team_salary 編集ルーチン（BLOCKING）
+`tools/team_salary` は別リポ（github.com/miyashita337/team_salary）の submodule。convert-service 内から直接編集して親で commit すると submodule pointer のみ進み、実体の変更は team_salary 側に置き去りになる。**必ず以下の手順で team_salary 側に PR を作る**。
+
+```bash
+# 1. 編集セッション開始 (submodule 側で feature ブランチ作成)
+cd tools/team_salary
+git fetch origin && git checkout -B feat/<topic> origin/main
+
+# 2. 編集 → commit → push → PR (team_salary 側)
+# ... 編集 ...
+git add <file>...                          # git add . は禁止
+git commit -m "<conventional message>"
+git push -u origin feat/<topic>
+gh pr create --repo miyashita337/team_salary --base main \
+  --title "..." --body "..."
+
+# 3. PR merge 後、convert-service 側で submodule pointer を bump
+cd "$(git rev-parse --show-toplevel)"
+bash scripts/bump-team-salary.sh           # submodule update --remote + commit
+# 必要なら convert-service 側も PR 化して push
+```
+
+- **HTTPS push が HTTP 400 で失敗した場合**: `cd tools/team_salary && git config http.version HTTP/1.1` で回避（HTTP/2 chunked が GitHub と相性悪い既知問題）
+- **自動投稿スクリプト等の WIP 退避**: 同じルーチンで `wip/<topic>` ブランチに commit & push して退避できる
+
 ## エピック・ロードマップ
 詳細: [グランドデザイン](docs/GRAND_DESIGN.md)
 ロードマップ: https://github.com/users/miyashita337/projects/2

--- a/scripts/bump-team-salary.sh
+++ b/scripts/bump-team-salary.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# tools/team_salary の submodule pointer を origin/main の最新に進めて commit する。
+# PR merge 後、convert-service 側で実行する想定。
+#
+# Usage:
+#   bash scripts/bump-team-salary.sh [--no-commit]
+#
+# Options:
+#   --no-commit  pointer 更新のみ、commit はしない（手動 commit したい場合）
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ ! -d tools/team_salary ]]; then
+  echo "[bump-team-salary] tools/team_salary が見つかりません" >&2
+  exit 1
+fi
+
+NO_COMMIT=0
+if [[ "${1:-}" == "--no-commit" ]]; then
+  NO_COMMIT=1
+fi
+
+OLD_SHA=$(git submodule status tools/team_salary | awk '{print $1}' | sed 's/^[+-]//')
+git submodule update --remote tools/team_salary
+NEW_SHA=$(cd tools/team_salary && git rev-parse HEAD)
+NEW_SHORT=$(cd tools/team_salary && git rev-parse --short HEAD)
+
+if [[ "$OLD_SHA" == "$NEW_SHA" ]]; then
+  echo "[bump-team-salary] 既に最新 ($NEW_SHORT)。何もしません。"
+  exit 0
+fi
+
+echo "[bump-team-salary] $OLD_SHA -> $NEW_SHA"
+
+if [[ $NO_COMMIT -eq 1 ]]; then
+  echo "[bump-team-salary] --no-commit 指定のため commit せず終了。手動で 'git add tools/team_salary && git commit' してください。"
+  exit 0
+fi
+
+LATEST_MSG=$(cd tools/team_salary && git log -1 --pretty=%s)
+
+git add tools/team_salary
+git commit -m "chore: bump team_salary to ${NEW_SHORT} (${LATEST_MSG})"
+
+echo "[bump-team-salary] commit 完了。push する場合: git push origin <branch>"

--- a/scripts/bump-team-salary.sh
+++ b/scripts/bump-team-salary.sh
@@ -10,7 +10,8 @@
 
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# スクリプト自身の場所を基準にリポジトリルートへ移動（submodule 内から呼ばれても堅牢）
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if [[ ! -d tools/team_salary ]]; then
   echo "[bump-team-salary] tools/team_salary が見つかりません" >&2
@@ -23,9 +24,9 @@ if [[ "${1:-}" == "--no-commit" ]]; then
 fi
 
 OLD_SHA=$(git submodule status tools/team_salary | awk '{print $1}' | sed 's/^[+-]//')
-git submodule update --remote tools/team_salary
-NEW_SHA=$(cd tools/team_salary && git rev-parse HEAD)
-NEW_SHORT=$(cd tools/team_salary && git rev-parse --short HEAD)
+git submodule update --init --remote tools/team_salary
+NEW_SHA=$(git -C tools/team_salary rev-parse HEAD)
+NEW_SHORT=$(git -C tools/team_salary rev-parse --short HEAD)
 
 if [[ "$OLD_SHA" == "$NEW_SHA" ]]; then
   echo "[bump-team-salary] 既に最新 ($NEW_SHORT)。何もしません。"
@@ -39,7 +40,7 @@ if [[ $NO_COMMIT -eq 1 ]]; then
   exit 0
 fi
 
-LATEST_MSG=$(cd tools/team_salary && git log -1 --pretty=%s)
+LATEST_MSG=$(git -C tools/team_salary log -1 --pretty=%s)
 
 git add tools/team_salary
 git commit -m "chore: bump team_salary to ${NEW_SHORT} (${LATEST_MSG})"


### PR DESCRIPTION
## 概要
`tools/team_salary` は別リポ（github.com/miyashita337/team_salary）の submodule。convert-service 内から直接編集して親で commit すると submodule pointer のみが進み、実体の変更は team_salary 側に届かない（迂回事故が頻発していた）。

本 PR では「team_salary 側で feature ブランチを切って PR を作る」標準ルーチンを明文化し、PR merge 後に呼び出すヘルパースクリプトも追加する。

## 主な変更点
- `CLAUDE.md`: `tools/team_salary 編集ルーチン (BLOCKING)` セクション追加
  - submodule 側で feature ブランチ作成 → 編集 → commit → push → `gh pr create --repo miyashita337/team_salary` の標準フロー
  - HTTP 400 (HTTP/2 chunked) の既知問題への対処（`http.version HTTP/1.1`）を併記
- `scripts/bump-team-salary.sh`: PR merge 後に呼ぶヘルパー
  - `git submodule update --remote tools/team_salary` で pointer を最新に進める
  - 自動で `chore: bump team_salary to <sha> (<latest msg>)` で commit
  - `--no-commit` オプションで pointer 更新のみも可

## 初回適用例
本ルーチンを使って team_salary#153 を作成済（SNS ローンチ投稿の自律実行を許可するルール変更）。

- https://github.com/miyashita337/team_salary/pull/153

## テスト方法
- [ ] CLAUDE.md の手順を読んで再現可能か確認
- [ ] `bash scripts/bump-team-salary.sh --no-commit` の dry-run 動作確認
- [ ] team_salary#153 merge 後、`bash scripts/bump-team-salary.sh` を実機実行して pointer 更新が正しく行われることを確認

## 影響範囲
ドキュメント + ヘルパースクリプトのみ。既存コード・CI に影響なし。