### PR TITLE
docs: 記事 005 / 004 の note + Qiita 公開後 URL を frontmatter に記録

### DIFF
--- a/docs/articles/004-webp-to-png.md
+++ b/docs/articles/004-webp-to-png.md
@@ -2,15 +2,15 @@
 title: "WebPをPNGに変換する最も簡単な方法【2026年版】"
 description: "Webサイトからダウンロードした.webp画像が編集ソフトで開けない問題を解決。WebPの基礎知識とブラウザだけで完結するPNG変換手順を、現役の画像変換サービス開発者が解説します。"
 tags: ["WebP", "PNG", "画像変換", "ブログ", "Canva"]
-canonical_url: ""
-published: false
-published_at: ""
+canonical_url: "https://note.com/quickconv/n/n75b3ce30008b"
+published: true
+published_at: "2026-05-01"
 platforms:
   hashnode: ""
   devto: ""
   medium: ""
-  note: ""
-  qiita: ""
+  note: "https://note.com/quickconv/n/n75b3ce30008b"
+  qiita: "https://qiita.com/quickconv/items/ea94f0e954621a91bf2c"
   zenn: ""
 cover_image: "./images/004-webp-to-png/header-webp-to-png.png"
 ---

--- a/docs/articles/005-mp4-to-mp3.md
+++ b/docs/articles/005-mp4-to-mp3.md
@@ -2,16 +2,16 @@
 title: "動画から音声だけ抽出する方法【MP4→MP3 変換 完全ガイド 2026】"
 description: "講義動画やセミナー録画を通勤中に音声で聞き直したい。会議録音から議事録用の音声だけ取り出したい。FFmpeg を使わず、ブラウザだけで MP4→MP3 変換を完結する手順を、画像変換サービス開発者が解説します。"
 tags: ["MP4", "MP3", "動画変換", "音声抽出", "QuickConv"]
-canonical_url: ""
+canonical_url: "https://note.com/quickconv/n/n37481b4cd5fb"
 cover_image: "./images/005-mp4-to-mp3/header-mp4-to-mp3.png"
-published: false
-published_at: ""
+published: true
+published_at: "2026-05-01"
 platforms:
   hashnode: ""
   devto: ""
   medium: ""
-  note: ""
-  qiita: ""
+  note: "https://note.com/quickconv/n/n37481b4cd5fb"
+  qiita: "https://qiita.com/quickconv/items/e2a530a63772ab54263f"
   zenn: ""
 ---
 


### PR DESCRIPTION
## 概要

QuickConv 記事 005 (MP4→MP3) / 004 (WebP→PNG) の note + Qiita 投稿が完了したため、frontmatter の `canonical_url` / `published` / `published_at` / `platforms.{note,qiita}` を実値で更新。

## 公開後 URL

| 記事 | note | Qiita | X (拡散) |
|---|---|---|---|
| 005 (MP4→MP3) | https://note.com/quickconv/n/n37481b4cd5fb | https://qiita.com/quickconv/items/e2a530a63772ab54263f | https://x.com/i/status/2050165119095816310 |
| 004 (WebP→PNG) | https://note.com/quickconv/n/n75b3ce30008b | https://qiita.com/quickconv/items/ea94f0e954621a91bf2c | https://x.com/i/status/2050165139773726734 |

## 投稿フロー (実行済み)

1. ✅ team_salary 側 4 スクリプト整備 (PR #166 / submodule bump #308)
2. ✅ note 下書き作成 + 画像 2 枚挿入 (`post-quickconv-draft.ts` + `insert-quickconv-images.ts`)
3. ✅ ユーザー手動公開 (RW-002 / AC「ユーザー手動公開」遵守)
4. ✅ Qiita API 投稿 + 生存確認 (`publish-quickconv-qiita.ts`、canonical=note URL を blockquote で記載)
5. ✅ X API シェア + permalink 200 検証 (`share-quickconv-x.ts`、RW-012)

## 関連 Issue

- #304 (MP4→MP3 投稿 tracker) — 本 PR で全 AC 完了
- #305 (WebP→PNG 投稿 tracker) — 本 PR で全 AC 完了
- 親 Epic #225 (E11 集客・グロース)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * WebP to PNG変換ガイドとMP4 to MP3変換ガイドの2つの新しい記事を公開しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->