### PR TITLE
docs: HN ドラフトの JPEG/PNG 想定 Q&A を実装に合わせて修正

### DIFF
--- a/docs/launch/hn-drafts.md
+++ b/docs/launch/hn-drafts.md
@@ -69,5 +69,5 @@ I'd love feedback on: UX, conversion quality, anything broken, or whether the pr
 ## 補足メモ
 
 - HNでバズったあとはサーバー負荷急増に注意。Cloudflare Workers + Cloud Run (max-instances=1) のため、同時接続が多いと Cloud Run のスケールアップが追いつかない可能性あり。投稿前に max-instances を一時的に上げることを検討。
-- コメントで「JPEG/PNG への変換はないのか」と聞かれる可能性がある。回答案: "We support JPG/PNG as input *and* output — the focus is converting them into next-gen formats like WebP/AVIF, and back to JPG/PNG when wider compatibility is needed. The gap we close is the AVIF/HEIC tooling around them."
+- コメントで「JPEG/PNG への変換はないのか」と聞かれる可能性がある。回答案: "We support JPG/PNG as input *and* output — the focus is converting them into next-gen formats like WebP/AVIF, and back to JPG/PNG when wider compatibility is needed. We're closing the gap in AVIF/HEIC tooling."
 - Stripe 決済の動作確認を投稿前に必ず完了させること（Issue #262）。

--- a/docs/launch/hn-drafts.md
+++ b/docs/launch/hn-drafts.md
@@ -69,5 +69,5 @@ I'd love feedback on: UX, conversion quality, anything broken, or whether the pr
 ## 補足メモ
 
 - HNでバズったあとはサーバー負荷急増に注意。Cloudflare Workers + Cloud Run (max-instances=1) のため、同時接続が多いと Cloud Run のスケールアップが追いつかない可能性あり。投稿前に max-instances を一時的に上げることを検討。
-- コメントで「なぜ JPEG/PNG 変換をサポートしないのか」と聞かれる可能性が高い。回答案: "Deliberately scoped to next-gen formats. JPEG/PNG converters are everywhere; the gap was in AVIF/HEIC tooling."
+- コメントで「JPEG/PNG への変換はないのか」と聞かれる可能性がある。回答案: "We support JPG/PNG as input *and* output — the focus is converting them into next-gen formats like WebP/AVIF, and back to JPG/PNG when wider compatibility is needed. The gap we close is the AVIF/HEIC tooling around them."
 - Stripe 決済の動作確認を投稿前に必ず完了させること（Issue #262）。


### PR DESCRIPTION
## 概要

`docs/launch/hn-drafts.md` 行72 の HN コメント想定 Q&A が実装と矛盾していた問題を修正。

## 変更内容

- 想定質問: 「なぜ JPEG/PNG 変換をサポートしないのか」 → 「JPEG/PNG への変換はないのか」
- 回答案を「Deliberately scoped to next-gen formats」から「入出力両対応で、次世代フォーマットへの変換が主軸」に書き換え

## 根拠（実装側のファクト）

`packages/shared/src/types/conversion.ts` の `CONVERSION_PAIRS`:

- `jpg` / `jpeg` → `png/webp/avif/ico/tiff/pdf`
- `png` → `jpg/webp/avif/ico/tiff/pdf`
- `heic` / `avif` / `webp` → `jpg/png/...`

つまり JPEG/PNG は入力にも出力にも対応している。Q&A の前提が誤っていた。

## テスト

ドキュメントの文章 1 箇所修正のみ。コード変更なし、テスト不要。

Closes #286