### PR TITLE
fix(web,api): Compare Quality の Failed to fetch エラーを修正 (#275)

### DIFF
--- a/apps/api/src/__tests__/converter.test.ts
+++ b/apps/api/src/__tests__/converter.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for converter service. Issue #275: ensure preview subrequest is
+ * cancelled with a deterministic AbortSignal so a hung Cloud Run cold start
+ * fails fast rather than letting the Worker tear the connection down — which
+ * surfaces in the browser as a generic "Failed to fetch" TypeError.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { requestPreviewConversion } from "../services/converter";
+
+describe("requestPreviewConversion", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("forwards a cancellable AbortSignal to the converter fetch", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ previews: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await requestPreviewConversion("http://converter", "k", {
+      fileBody: new ArrayBuffer(8),
+      fileName: "x.png",
+      outputFormat: "webp",
+      qualities: [70],
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("returns success=false on non-2xx without throwing", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("boom", { status: 500 }));
+
+    const result = await requestPreviewConversion("http://converter", "k", {
+      fileBody: new ArrayBuffer(8),
+      fileName: "x.png",
+      outputFormat: "webp",
+      qualities: [70],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("500");
+  });
+
+  test("translates AbortError to a friendly error message", async () => {
+    fetchMock.mockImplementationOnce(() => {
+      const err = new Error("The operation was aborted");
+      err.name = "AbortError";
+      return Promise.reject(err);
+    });
+
+    const result = await requestPreviewConversion("http://converter", "k", {
+      fileBody: new ArrayBuffer(8),
+      fileName: "x.png",
+      outputFormat: "webp",
+      qualities: [70],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to reach converter");
+  });
+});

--- a/apps/api/src/services/converter.ts
+++ b/apps/api/src/services/converter.ts
@@ -88,6 +88,14 @@ export async function requestDirectConversion(
   }
 }
 
+/**
+ * Converter subrequest timeout. Cloud Run cold start can take 10-30s; 60s
+ * leaves headroom for the conversion itself while keeping us inside Worker
+ * subrequest limits and avoiding mid-flight resets that surface in the browser
+ * as "Failed to fetch".
+ */
+const CONVERTER_TIMEOUT_MS = 60_000;
+
 export async function requestPreviewConversion(
   converterUrl: string,
   apiKey: string,
@@ -103,6 +111,7 @@ export async function requestPreviewConversion(
       method: "POST",
       headers: { Authorization: `Bearer ${apiKey}` },
       body: formData,
+      signal: AbortSignal.timeout(CONVERTER_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/apps/web/e2e/quality-preview.spec.ts
+++ b/apps/web/e2e/quality-preview.spec.ts
@@ -186,6 +186,40 @@ test.describe("Quality comparison preview", () => {
     );
     await expect(convertBtn.first()).toBeVisible({ timeout: 10_000 });
   });
+
+  // Issue #275: Compare Quality must complete without "Failed to fetch" in
+  // the console, AND the slider DOM must appear once a preview is selected.
+  test("compare quality completes without Failed to fetch and renders slider (#275)", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    const previewResponses: number[] = [];
+    page.on("response", (res) => {
+      if (res.url().includes("/api/preview")) previewResponses.push(res.status());
+    });
+
+    await setupPreview(page, testFilePath);
+
+    const compareBtn = page.getByRole("button", { name: /Compare Quality|品質を比較/i });
+    await compareBtn.click();
+
+    // Slider should appear within 30s (covers Cloud Run cold start + retry)
+    const slider = page.locator('[data-testid="image-compare-slider"]');
+    await expect(slider).toBeVisible({ timeout: 30_000 });
+
+    // No "Failed to fetch" in any error sink
+    const allErrors = [...consoleErrors, ...pageErrors].join("\n");
+    expect(allErrors).not.toContain("Failed to fetch");
+
+    // /api/preview must have completed at least once with 2xx
+    expect(previewResponses.some((s) => s >= 200 && s < 300)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/e2e/quality-preview.spec.ts
+++ b/apps/web/e2e/quality-preview.spec.ts
@@ -209,9 +209,11 @@ test.describe("Quality comparison preview", () => {
     const compareBtn = page.getByRole("button", { name: /Compare Quality|品質を比較/i });
     await compareBtn.click();
 
-    // Slider should appear within 30s (covers Cloud Run cold start + retry)
+    // Slider should appear within 60s — leaves headroom for Cloud Run cold
+    // start (~30s) + a single client retry (≈1s backoff + a second attempt
+    // sharing the 90s deadline budget).
     const slider = page.locator('[data-testid="image-compare-slider"]');
-    await expect(slider).toBeVisible({ timeout: 30_000 });
+    await expect(slider).toBeVisible({ timeout: 60_000 });
 
     // No "Failed to fetch" in any error sink
     const allErrors = [...consoleErrors, ...pageErrors].join("\n");

--- a/apps/web/src/__tests__/request-preview.test.ts
+++ b/apps/web/src/__tests__/request-preview.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for `requestPreview` retry/timeout behavior.
+ *
+ * Issue #275: "Compare Quality で Failed to fetch エラー" — transient browser
+ * fetch TypeError must surface as a single retry, not an immediate failure.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { requestPreview } from "../lib/api-client";
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+const errResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const sampleResponse = {
+  previews: [{ quality: 70, size: 100, compressionRatio: 0.5, data: "data:image/webp;base64,AA" }],
+  requestedCount: 1,
+  returnedCount: 1,
+  plan: "free",
+};
+
+const sampleFile = () => new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], "x.png", { type: "image/png" });
+
+describe("requestPreview", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  test("returns parsed body on first success", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(sampleResponse));
+
+    const promise = requestPreview(sampleFile(), "webp", [70], "free");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual(sampleResponse);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries once on transient TypeError (Failed to fetch)", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(okResponse(sampleResponse));
+
+    const promise = requestPreview(sampleFile(), "webp", [70], "free");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual(sampleResponse);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry on HTTP error (e.g. 400 validation)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      errResponse(400, { message: "outputFormat is required" }),
+    );
+
+    // Attach the rejection handler BEFORE pumping timers so the promise is
+    // never observed as unhandled while in fake-timer pump.
+    const assertion = expect(
+      requestPreview(sampleFile(), "webp", [70], "free"),
+    ).rejects.toThrow("outputFormat is required");
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("surfaces second failure when retry also fails", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    const assertion = expect(
+      requestPreview(sampleFile(), "webp", [70], "free"),
+    ).rejects.toThrow("Failed to fetch");
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("passes an AbortSignal so the request can time out", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(sampleResponse));
+
+    const promise = requestPreview(sampleFile(), "webp", [70], "free");
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/apps/web/src/components/image-compare-slider.tsx
+++ b/apps/web/src/components/image-compare-slider.tsx
@@ -86,7 +86,7 @@ export function ImageCompareSlider({
   }, [afterSrc]);
 
   return (
-    <div className={cn("w-full", className)}>
+    <div className={cn("w-full", className)} data-testid="image-compare-slider">
       {/* Size reduction badge */}
       <div className="flex items-center justify-center gap-2 mb-3">
         <span

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -171,10 +171,17 @@ const PREVIEW_TIMEOUT_MS = 90_000;
 /** Backoff delay before single retry on transient network errors (ms). */
 const PREVIEW_RETRY_DELAY_MS = 1_000;
 
-/** A network-level failure where retrying may help (TypeError "Failed to fetch", AbortError). */
+/** A network-level failure where retrying may help. Some browsers / runtimes
+ *  emit `TimeoutError` from `AbortSignal.timeout(...)` in addition to the
+ *  classic `TypeError: Failed to fetch` and the `AbortError` we raise from
+ *  our own AbortController. Treat all three as retryable. */
 function isTransientFetchError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  return err.name === "TypeError" || err.name === "AbortError";
+  return (
+    err.name === "TypeError" ||
+    err.name === "AbortError" ||
+    err.name === "TimeoutError"
+  );
 }
 
 async function preview_fetchOnce(
@@ -216,9 +223,18 @@ export async function requestPreview(
     return fd;
   };
 
+  // Use a single absolute deadline so retry never extends UX latency past the
+  // total budget. Without this, the worst case is 90s (attempt 1 timeout) +
+  // 1s (backoff) + 90s (attempt 2 timeout) ≈ 181s.
+  const deadline = Date.now() + PREVIEW_TIMEOUT_MS;
+
   const attempt = async () => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error("Preview request timed out");
+    }
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), PREVIEW_TIMEOUT_MS);
+    const timeoutId = setTimeout(() => controller.abort(), remaining);
     try {
       return await preview_fetchOnce(buildFormData(), controller.signal);
     } finally {
@@ -230,6 +246,7 @@ export async function requestPreview(
     return await attempt();
   } catch (err) {
     if (!isTransientFetchError(err)) throw err;
+    if (Date.now() + PREVIEW_RETRY_DELAY_MS >= deadline) throw err;
     await new Promise((r) => setTimeout(r, PREVIEW_RETRY_DELAY_MS));
     return attempt();
   }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -166,27 +166,71 @@ export function connectJobStream(
   return () => eventSource.close();
 }
 
+/** Preview request timeout (ms). Long enough for Cloud Run cold start (~30s) + 4 conversions. */
+const PREVIEW_TIMEOUT_MS = 90_000;
+/** Backoff delay before single retry on transient network errors (ms). */
+const PREVIEW_RETRY_DELAY_MS = 1_000;
+
+/** A network-level failure where retrying may help (TypeError "Failed to fetch", AbortError). */
+function isTransientFetchError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === "TypeError" || err.name === "AbortError";
+}
+
+async function preview_fetchOnce(
+  formData: FormData,
+  signal: AbortSignal,
+): Promise<PreviewResponse> {
+  const res = await fetch(`${API_URL}/api/preview`, {
+    method: "POST",
+    body: formData,
+    signal,
+  });
+
+  if (!res.ok) {
+    let message = "Preview request failed";
+    try {
+      const error = (await res.json()) as { message?: string };
+      if (error?.message) message = error.message;
+    } catch {
+      // body was not JSON; keep default message
+    }
+    throw new Error(message);
+  }
+
+  return res.json();
+}
+
 export async function requestPreview(
   file: File,
   outputFormat: string,
   qualities: number[],
   plan: string,
 ): Promise<PreviewResponse> {
-  const formData = new FormData();
-  formData.append("file", file);
-  formData.append("outputFormat", outputFormat);
-  formData.append("qualities", JSON.stringify(qualities));
-  formData.append("plan", plan);
+  const buildFormData = () => {
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("outputFormat", outputFormat);
+    fd.append("qualities", JSON.stringify(qualities));
+    fd.append("plan", plan);
+    return fd;
+  };
 
-  const res = await fetch(`${API_URL}/api/preview`, {
-    method: "POST",
-    body: formData,
-  });
+  const attempt = async () => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), PREVIEW_TIMEOUT_MS);
+    try {
+      return await preview_fetchOnce(buildFormData(), controller.signal);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
 
-  if (!res.ok) {
-    const error = await res.json();
-    throw new Error(error.message || "Preview request failed");
+  try {
+    return await attempt();
+  } catch (err) {
+    if (!isTransientFetchError(err)) throw err;
+    await new Promise((r) => setTimeout(r, PREVIEW_RETRY_DELAY_MS));
+    return attempt();
   }
-
-  return res.json();
 }


### PR DESCRIPTION
## Summary

Issue #275 「Compare Quality で Failed to fetch エラー」の修正。

ブラウザ側の `TypeError: Failed to fetch` は、Cloud Run の cold start や Worker の subrequest 中断で
レスポンスが mid-flight に切れたときに発生していた。3 層で耐性を持たせる。

### 変更内容

| 層 | 変更 | 目的 |
|---|---|---|
| Frontend | `requestPreview` に 90s timeout + 1 回リトライ（`TypeError`/`AbortError`） | 一過性の network failure を救済 |
| Frontend | `ImageCompareSlider` に `data-testid="image-compare-slider"` | 統合ジャーニーAC の決定的検証用 |
| API | converter subrequest に 60s `AbortSignal.timeout` | Cloud Run cold start で hung せず明示的にエラーを返す |

### テスト

- 新規 unit (web): `requestPreview` の retry / timeout / non-retry on HTTP error / signal 伝播 → 5/5 PASS
- 新規 unit (api): `requestPreviewConversion` の `AbortSignal` 伝播 / 500 / AbortError → 3/3 PASS
- 新規 E2E: `compare quality completes without Failed to fetch and renders slider (#275)` (production project で実行)
- 全体: web 17/17 PASS、api 120/120 PASS、`tsc --noEmit` クリーン、`pnpm build` 成功

### 統合ジャーニーAC（Issue #275）

| # | 操作 | 期待結果 | 検証手段 |
|---|---|---|---|
| 1 | quickconv.cc/en で PNG 2MB → WEBP → Compare Quality | スライダー表示 | E2E: `[data-testid="image-compare-slider"]` visible 内 30s + console に `Failed to fetch` 無し |
| 2 | スライダーをドラッグ | 変換前後画像が連続表示 | E2E: `/api/preview` POST が 200 を返すこと |

## Test plan

- [x] `pnpm test` (web + api) で全テスト PASS
- [x] `pnpm run lint` で型チェッククリーン
- [x] `pnpm build` で全パッケージビルド成功
- [ ] CI（lint / build / test / staging deploy）が green
- [ ] staging E2E（`e2e-stg`）で Compare Quality 新規テストが PASS
- [ ] 本番デプロイ後、`E2E_TARGET=production` で `quality-preview.spec.ts` の #275 テストを実機検証

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プレビューリクエストにクライアント側のタイムアウト保護を追加し、ハングアップを防止しました。
  * 一時的なネットワーク障害時の自動リトライ機能を実装し、プレビュー取得の信頼性を向上させました。
  * エラーレスポンス時のエラーメッセージ処理を改善し、ユーザーへの情報表示をより正確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->