### PR TITLE
chore(e2e): staging CI の認証 email を E2E 専用エイリアスに分離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           RESPONSE=$(curl -sf --retry 3 -X POST "https://api-staging.quickconv.cc/api/test/token" \
             -H "Content-Type: application/json" \
             -H "X-E2E-Secret: ${E2E_TEST_SECRET}" \
-            -d '{"email":"proce55ingpurser@gmail.com","plan":"free"}') || { echo "::error::Failed to fetch E2E token"; exit 1; }
+            -d '{"email":"e2e+staging@quickconv.cc","plan":"free"}') || { echo "::error::Failed to fetch E2E token"; exit 1; }
           TOKEN=$(echo "$RESPONSE" | jq -r '.token')
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
             echo "::error::E2E token is empty or null"


### PR DESCRIPTION
## 概要

PR #295 の調査で発覚した issue を解消する。staging CI の E2E 認証で使う email が **real Google OAuth ユーザーと同じ行を共有** しており、CI 毎に real user の `updated_at` が書き換わる副作用があった。

## 変更内容

- `.github/workflows/ci.yml` の test/token リクエストの email を変更
  - Before: `proce55ingpurser@gmail.com` (real user と衝突)
  - After: `e2e+staging@quickconv.cc` (独自ドメイン、衝突リスクゼロ)

## 解決すること

- real user 行 (`proce55ingpurser@gmail.com`) を CI が一切触らなくなる
- 新たな D1 行が `google_id = e2e-test:e2e+staging@quickconv.cc` で作られ、real user 運用と完全分離される (upsertE2ETestUser は新 email を新規行として INSERT する)

## AC

- [x] ci.yml で staging E2E が使う email を E2E 専用に変更
- [ ] staging D1 に `e2e+staging@quickconv.cc` 用の行が `e2e-test:e2e+staging@quickconv.cc` google_id で作られ、real user 行とは別に管理される (merge 後 main push の e2e-stg job で初回 INSERT、確認は AC 3 と一体)
- [ ] CI e2e-stg が引き続き PASS (merge 後 main の deploy-stg → e2e-stg 完走で確認)
- [ ] real user (`proce55ingpurser@gmail.com`) の updated_at が CI で変わらなくなる (#295 以降 4-5 PR の merge 経過で副次確認)

## 統合ジャーニーAC

不要 (理由: staging CI の E2E 認証メールエイリアスを変更するインフラ作業のみ。プロダクト側ユーザー操作フローは変更されず、検証は CI run の auth-state.json 生成と D1 行確認で決定的に行う)

## Test plan

- [x] PR push で `lint-and-build` job が PASS することを確認 (CI 自動)
- [ ] merge 後の main push で `deploy-stg` → `e2e-stg` job が PASS することを確認 (本番デプロイゲート)
- [ ] (任意) 旧 real user 行の `updated_at` が以後の CI で動かなくなることを確認

Closes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ステージング環境のテスト認証プロセスを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->