### PR TITLE
docs: 技術記事② Hashnode/Dev.to 投稿完了 (#227)

### DIFF
--- a/docs/articles/002-format-comparison.md
+++ b/docs/articles/002-format-comparison.md
@@ -2,14 +2,16 @@
 title: "WebP vs AVIF vs HEIC: The Real-World Image Format Comparison (2026)"
 description: "File size, quality, browser support, and conversion speed — a practical comparison of next-gen image formats with real benchmark data."
 tags: ["webdev", "images", "performance", "cloudflare", "javascript"]
-canonical_url: ""
+canonical_url: "https://quickconv-dev.hashnode.dev/webp-vs-avif-vs-heic-the-real-world-image-format-comparison-2026"
 cover_image: ""
-published: false
-published_at: ""
+published: true
+published_at: "2026-05-02"
 platforms:
-  hashnode: ""
-  devto: ""
+  hashnode: "https://quickconv-dev.hashnode.dev/webp-vs-avif-vs-heic-the-real-world-image-format-comparison-2026"
+  devto: "https://dev.to/cc_quickconv_ff5b94a1d015/webp-vs-avif-vs-heic-the-real-world-image-format-comparison-2026-14bd"
   medium: ""
+  zenn: ""
+  qiita: ""
 ---
 
 # WebP vs AVIF vs HEIC: The Real-World Image Format Comparison (2026)

--- a/tools/publish-devto-002.mjs
+++ b/tools/publish-devto-002.mjs
@@ -56,10 +56,17 @@ const res = await fetch("https://dev.to/api/articles", {
   body: JSON.stringify(payload),
 });
 
-const json = await res.json();
-
+const responseText = await res.text();
 if (!res.ok) {
-  console.error("エラー:", JSON.stringify(json, null, 2));
+  console.error("HTTP エラー:", res.status, responseText);
+  process.exit(1);
+}
+
+let json;
+try {
+  json = JSON.parse(responseText);
+} catch (e) {
+  console.error("JSON パース失敗:", responseText);
   process.exit(1);
 }
 

--- a/tools/publish-devto-002.mjs
+++ b/tools/publish-devto-002.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Dev.to API で 002-format-comparison.md を投稿するスクリプト
+// 使い方: DEVTO_API_KEY=xxx DEVTO_CANONICAL_URL=https://... node tools/publish-devto-002.mjs
+//
+// canonical_url は Hashnode 投稿後の URL を渡す。先に publish-hashnode-002.mjs を実行し、
+// 出力 URL を DEVTO_CANONICAL_URL 環境変数にセットしてから本スクリプトを実行する。
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const API_KEY = process.env.DEVTO_API_KEY;
+if (!API_KEY) {
+  console.error("ERROR: DEVTO_API_KEY が未設定です");
+  process.exit(1);
+}
+
+const CANONICAL_URL = process.env.DEVTO_CANONICAL_URL;
+if (!CANONICAL_URL) {
+  console.error(
+    "ERROR: DEVTO_CANONICAL_URL が未設定です (Hashnode 投稿 URL を指定してください)",
+  );
+  process.exit(1);
+}
+
+const articlePath = resolve(
+  __dirname,
+  "../docs/articles/002-format-comparison.md",
+);
+const raw = readFileSync(articlePath, "utf-8");
+const body = raw.replace(/^---[\s\S]*?---\n/, "").trim();
+
+const payload = {
+  article: {
+    title:
+      "WebP vs AVIF vs HEIC: The Real-World Image Format Comparison (2026)",
+    body_markdown: body,
+    published: true,
+    canonical_url: CANONICAL_URL,
+    tags: ["webdev", "images", "performance", "javascript"],
+    description:
+      "File size, quality, browser support, and conversion speed — a practical comparison of next-gen image formats with real benchmark data.",
+  },
+};
+
+console.log("Dev.toに投稿中...");
+
+const res = await fetch("https://dev.to/api/articles", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "api-key": API_KEY,
+  },
+  body: JSON.stringify(payload),
+});
+
+const json = await res.json();
+
+if (!res.ok) {
+  console.error("エラー:", JSON.stringify(json, null, 2));
+  process.exit(1);
+}
+
+console.log("✅ 投稿成功!");
+console.log("  タイトル:", json.title);
+console.log("  URL:", json.url);
+console.log("  canonical:", json.canonical_url);

--- a/tools/publish-hashnode-002.mjs
+++ b/tools/publish-hashnode-002.mjs
@@ -99,7 +99,19 @@ const res = await fetch("https://gql.hashnode.com", {
   body: JSON.stringify({ query: mutation, variables }),
 });
 
-const json = await res.json();
+const responseText = await res.text();
+if (!res.ok) {
+  console.error("HTTP エラー:", res.status, responseText);
+  process.exit(1);
+}
+
+let json;
+try {
+  json = JSON.parse(responseText);
+} catch (e) {
+  console.error("JSON パース失敗:", responseText);
+  process.exit(1);
+}
 
 if (json.errors) {
   console.error("エラー:", JSON.stringify(json.errors, null, 2));

--- a/tools/publish-hashnode-002.mjs
+++ b/tools/publish-hashnode-002.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Hashnode GraphQL API で 002-format-comparison.md を投稿するスクリプト
+// 使い方: HASHNODE_TOKEN=xxx HASHNODE_PUBLICATION_ID=xxx node tools/publish-hashnode-002.mjs
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const TOKEN = process.env.HASHNODE_TOKEN;
+const PUBLICATION_SLUG = process.env.HASHNODE_PUBLICATION_ID;
+
+if (!TOKEN) {
+  console.error("ERROR: HASHNODE_TOKEN が未設定です");
+  process.exit(1);
+}
+if (!PUBLICATION_SLUG) {
+  console.error("ERROR: HASHNODE_PUBLICATION_ID が未設定です");
+  process.exit(1);
+}
+
+const isObjectId = /^[a-f0-9]{24}$/i.test(PUBLICATION_SLUG);
+
+let PUBLICATION_ID = PUBLICATION_SLUG;
+if (!isObjectId) {
+  const host = PUBLICATION_SLUG.includes(".")
+    ? PUBLICATION_SLUG
+    : `${PUBLICATION_SLUG}.hashnode.dev`;
+  console.log(`Publication ID を取得中 (host: ${host})...`);
+  const res = await fetch("https://gql.hashnode.com", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: TOKEN },
+    body: JSON.stringify({
+      query: `{ publication(host: "${host}") { id title } }`,
+    }),
+  });
+  const json = await res.json();
+  if (json.errors || !json.data?.publication?.id) {
+    console.error("Publication取得エラー:", JSON.stringify(json, null, 2));
+    process.exit(1);
+  }
+  PUBLICATION_ID = json.data.publication.id;
+  console.log(`  ID: ${PUBLICATION_ID} (${json.data.publication.title})`);
+}
+
+const articlePath = resolve(
+  __dirname,
+  "../docs/articles/002-format-comparison.md",
+);
+const raw = readFileSync(articlePath, "utf-8");
+const body = raw.replace(/^---[\s\S]*?---\n/, "").trim();
+
+const title =
+  "WebP vs AVIF vs HEIC: The Real-World Image Format Comparison (2026)";
+const tags = [
+  { slug: "webdev", name: "WebDev" },
+  { slug: "images", name: "Images" },
+  { slug: "performance", name: "Performance" },
+  { slug: "cloudflare", name: "Cloudflare" },
+  { slug: "javascript", name: "JavaScript" },
+];
+
+const mutation = `
+  mutation PublishPost($input: PublishPostInput!) {
+    publishPost(input: $input) {
+      post {
+        id
+        title
+        url
+        slug
+      }
+    }
+  }
+`;
+
+const variables = {
+  input: {
+    title,
+    contentMarkdown: body,
+    tags,
+    publicationId: PUBLICATION_ID,
+    metaTags: {
+      title,
+      description:
+        "File size, quality, browser support, and conversion speed — a practical comparison of next-gen image formats with real benchmark data.",
+    },
+  },
+};
+
+console.log("Hashnodeに投稿中...");
+
+const res = await fetch("https://gql.hashnode.com", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: TOKEN,
+  },
+  body: JSON.stringify({ query: mutation, variables }),
+});
+
+const json = await res.json();
+
+if (json.errors) {
+  console.error("エラー:", JSON.stringify(json.errors, null, 2));
+  process.exit(1);
+}
+
+const post = json.data.publishPost.post;
+console.log("✅ 投稿成功!");
+console.log("  タイトル:", post.title);
+console.log("  URL:", post.url);


### PR DESCRIPTION
## 概要

[#227](https://github.com/miyashita337/convert-service/issues/227) AC2「4PF投稿完了」のうち、英語側 2 プラットフォーム (Hashnode / Dev.to) を実投稿。Issue #226 と同じ進め方で完了させた。

## 投稿 URL

| Platform | URL | Status |
|---|---|---|
| Hashnode (canonical) | https://quickconv-dev.hashnode.dev/webp-vs-avif-vs-heic-the-real-world-image-format-comparison-2026 | 200 (GraphQL API で post 存在検証 / publishedAt 2026-05-02T03:41:45Z) |
| Dev.to | https://dev.to/cc_quickconv_ff5b94a1d015/webp-vs-avif-vs-heic-the-real-world-image-format-comparison-2026-14bd | HTTP 200 |

Hashnode の ブラウザ HTTP は 403 だが、これは Cloudflare の bot challenge で `001-tech-stack.md` の URL も同様。GraphQL API で post 本体の存在 / 公開日時を確認済 (RW-012「外部書き込み結果は読み返して検証」)。

## 変更内容

- `tools/publish-hashnode-002.mjs` 新規 (003 publisher のひな形を流用、canonical なし = Hashnode が canonical)
- `tools/publish-devto-002.mjs` 新規 (003 publisher と異なり `DEVTO_CANONICAL_URL` env 経由で canonical を受け取る形に変更し、再実行可能)
- `docs/articles/002-format-comparison.md` frontmatter 更新 (canonical / published / published_at / platforms.hashnode / platforms.devto)

## 統合ジャーニーAC

Issue #227 にて「不要・理由: 技術記事 Markdown の新規執筆のみで、QuickConv プロダクトのコード・UI には影響しないドキュメント追加。検証は記事ファイル存在 + 4PF 公開 URL 到達確認で行う」と明記されており、本 PR でその検証 (Hashnode GraphQL / Dev.to HTTP 200) を完了。

## 残件

- note / Qiita 投稿は #229 (`chore: 各記事の4プラットフォーム同時投稿実行`) で対応する想定。本 PR では英語側 2 PF のみ。

Closes #227