### PR TITLE
fix(ci): CI失敗時のPushover通知を確実に届くようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,38 +236,126 @@ jobs:
           retention-days: 7
 
   # ── Stage 6: Notify ────────────────────────────────────────────
+  # 設計方針 (Issue #294):
+  # - 全ステージの失敗を捕捉 (needs に全 job 列挙)
+  # - notify job 自体は常に成功扱いにして「通知役自身が落ちる」事故を排除
+  # - Pushover が失敗 or secrets 未設定なら GitHub Issue 起票でフォールバック
   notify:
     runs-on: ubuntu-latest
-    needs: [e2e-stg, deploy-prod, e2e-prod]
+    needs: [lint-and-build, test, deploy-stg, e2e-stg, deploy-prod, e2e-prod]
     if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - name: Determine result
+      - name: Aggregate job results
         id: result
+        env:
+          R_LINT: ${{ needs.lint-and-build.result }}
+          R_TEST: ${{ needs.test.result }}
+          R_DEPLOY_STG: ${{ needs.deploy-stg.result }}
+          R_E2E_STG: ${{ needs.e2e-stg.result }}
+          R_DEPLOY_PROD: ${{ needs.deploy-prod.result }}
+          R_E2E_PROD: ${{ needs.e2e-prod.result }}
         run: |
-          if [[ "${{ needs.e2e-stg.result }}" == "failure" ]]; then
-            echo "status=FAIL" >> "$GITHUB_OUTPUT"
-            echo "message=Staging E2E failed — production deploy was blocked" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ needs.deploy-prod.result }}" == "failure" ]]; then
-            echo "status=FAIL" >> "$GITHUB_OUTPUT"
-            echo "message=Production deploy failed" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ needs.e2e-prod.result }}" == "failure" ]]; then
-            echo "status=FAIL" >> "$GITHUB_OUTPUT"
-            echo "message=Production E2E failed — deployed code may have issues" >> "$GITHUB_OUTPUT"
-          else
+          FAILED=()
+          [[ "$R_LINT" == "failure" ]] && FAILED+=("lint-and-build")
+          [[ "$R_TEST" == "failure" ]] && FAILED+=("test")
+          [[ "$R_DEPLOY_STG" == "failure" ]] && FAILED+=("deploy-stg")
+          [[ "$R_E2E_STG" == "failure" ]] && FAILED+=("e2e-stg")
+          [[ "$R_DEPLOY_PROD" == "failure" ]] && FAILED+=("deploy-prod")
+          [[ "$R_E2E_PROD" == "failure" ]] && FAILED+=("e2e-prod")
+
+          if [[ ${#FAILED[@]} -eq 0 ]]; then
             echo "status=PASS" >> "$GITHUB_OUTPUT"
-            echo "message=All stages passed" >> "$GITHUB_OUTPUT"
+            echo "failed_jobs=" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=FAIL" >> "$GITHUB_OUTPUT"
+            echo "failed_jobs=$(IFS=,; echo "${FAILED[*]}")" >> "$GITHUB_OUTPUT"
           fi
-      - name: Send Pushover notification on failure
+      - name: Build notification payload
         if: steps.result.outputs.status == 'FAIL'
+        id: payload
+        env:
+          FAILED_JOBS: ${{ steps.result.outputs.failed_jobs }}
+          SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          SHORT_SHA="${SHA:0:7}"
+          COMMIT_TITLE=$(printf '%s' "$COMMIT_MSG" | head -n 1)
+          {
+            echo "short_sha=${SHORT_SHA}"
+            echo "commit_title=${COMMIT_TITLE}"
+            echo "title=QuickConv CI FAIL ${FAILED_JOBS}"
+            echo "url=https://github.com/${REPO}/actions/runs/${RUN_ID}"
+            echo "msg<<EOF"
+            echo "failed: ${FAILED_JOBS}"
+            echo "SHA: ${SHORT_SHA} (${COMMIT_TITLE})"
+            echo "Run: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Send Pushover notification
+        if: steps.result.outputs.status == 'FAIL'
+        id: pushover
+        continue-on-error: true
         env:
           PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}
           PUSHOVER_API_TOKEN: ${{ secrets.PUSHOVER_API_TOKEN }}
+          TITLE: ${{ steps.payload.outputs.title }}
+          MSG: ${{ steps.payload.outputs.msg }}
+          URL: ${{ steps.payload.outputs.url }}
         run: |
-          curl -sf -X POST "https://api.pushover.net/1/messages.json" \
-            -d "token=${PUSHOVER_API_TOKEN}" \
-            -d "user=${PUSHOVER_USER_KEY}" \
-            -d "title=QuickConv CI: ${{ steps.result.outputs.status }}" \
-            -d "message=${{ steps.result.outputs.message }}" \
-            -d "url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -d "url_title=View Run" \
-            -d "priority=1"
+          if [[ -z "$PUSHOVER_USER_KEY" || -z "$PUSHOVER_API_TOKEN" ]]; then
+            echo "::warning::PUSHOVER_USER_KEY or PUSHOVER_API_TOKEN is not set in repository secrets"
+            exit 1
+          fi
+          HTTP_CODE=$(curl -sS -o /tmp/pushover_resp.txt -w "%{http_code}" \
+            -X POST "https://api.pushover.net/1/messages.json" \
+            --data-urlencode "token=${PUSHOVER_API_TOKEN}" \
+            --data-urlencode "user=${PUSHOVER_USER_KEY}" \
+            --data-urlencode "title=${TITLE}" \
+            --data-urlencode "message=${MSG}" \
+            --data-urlencode "url=${URL}" \
+            --data-urlencode "url_title=View Run" \
+            --data-urlencode "priority=1")
+          echo "Pushover HTTP ${HTTP_CODE}"
+          cat /tmp/pushover_resp.txt || true
+          if [[ "$HTTP_CODE" != "200" ]]; then
+            echo "::warning::Pushover API returned HTTP ${HTTP_CODE}"
+            exit 1
+          fi
+          echo "Pushover notification sent successfully"
+      - name: Fallback to GitHub Issue
+        if: steps.result.outputs.status == 'FAIL' && steps.pushover.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          FAILED_JOBS: ${{ steps.result.outputs.failed_jobs }}
+          SHORT_SHA: ${{ steps.payload.outputs.short_sha }}
+          COMMIT_TITLE: ${{ steps.payload.outputs.commit_title }}
+          RUN_URL: ${{ steps.payload.outputs.url }}
+        run: |
+          TITLE="[ci-fail] CI failure on main: ${FAILED_JOBS} (${SHORT_SHA})"
+          EXISTING=$(gh issue list --repo "$REPO" --label ci-failure --state open \
+            --search "${SHORT_SHA} in:title" --json number --jq '.[0].number // empty')
+          if [[ -n "$EXISTING" ]]; then
+            echo "Issue #${EXISTING} already exists for SHA ${SHORT_SHA}, skipping"
+            exit 0
+          fi
+          gh label create ci-failure --repo "$REPO" \
+            --color d73a4a --description "Auto-created when CI fails on main" \
+            2>/dev/null || true
+          BODY_FILE=$(mktemp)
+          {
+            printf '%s\n\n' "Pushover 通知が失敗または secrets 未設定のため、自動起票しました。"
+            printf '%s `%s`\n' "**Failed jobs**:" "${FAILED_JOBS}"
+            printf '%s %s — %s\n' "**Commit**:" "${SHORT_SHA}" "${COMMIT_TITLE}"
+            printf '%s %s\n\n' "**Run**:" "${RUN_URL}"
+            printf '%s\n' "通知を有効化するには Repository Settings → Secrets and variables → Actions に \`PUSHOVER_USER_KEY\` / \`PUSHOVER_API_TOKEN\` を登録してください。手順は \`docs/deploy.md\` を参照。"
+          } > "$BODY_FILE"
+          gh issue create --repo "$REPO" \
+            --title "$TITLE" \
+            --label ci-failure \
+            --body-file "$BODY_FILE"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -135,3 +135,28 @@ curl https://api-staging.quickconv.cc/health
 # Workers dev URL でも確認可能
 # https://quickconv-api-staging.<account>.workers.dev
 ```
+
+## CI 通知 (Pushover)
+
+main ブランチ CI が失敗したら自動で Pushover 通知が飛ぶ。secrets が未設定または Pushover API が落ちていた場合は `ci-failure` ラベル付きの Issue が自動起票されるので無通知放置にはならない。
+
+### 初回セットアップ
+
+```bash
+# Pushover で取得した値を Repository Secrets に登録
+gh secret set PUSHOVER_USER_KEY --repo miyashita337/convert-service
+gh secret set PUSHOVER_API_TOKEN --repo miyashita337/convert-service
+
+# 登録確認
+gh secret list --repo miyashita337/convert-service | grep PUSHOVER
+```
+
+### 動作確認
+
+```bash
+# 既存の失敗 run で notify job を再実行
+gh run list --workflow=ci.yml --branch=main --status=failure --limit=1 --json databaseId --jq '.[0].databaseId'
+gh run rerun <RUN_ID> --job notify
+```
+
+成功時は実機 Pushover に届く / 失敗時は `gh issue list --label ci-failure` に起票される。

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -143,12 +143,12 @@ main ブランチ CI が失敗したら自動で Pushover 通知が飛ぶ。secr
 ### 初回セットアップ
 
 ```bash
-# Pushover で取得した値を Repository Secrets に登録
-gh secret set PUSHOVER_USER_KEY --repo miyashita337/convert-service
-gh secret set PUSHOVER_API_TOKEN --repo miyashita337/convert-service
+# Pushover で取得した値を Repository Secrets に登録 (リポジトリ root で実行)
+gh secret set PUSHOVER_USER_KEY
+gh secret set PUSHOVER_API_TOKEN
 
 # 登録確認
-gh secret list --repo miyashita337/convert-service | grep PUSHOVER
+gh secret list | grep PUSHOVER
 ```
 
 ### 動作確認


### PR DESCRIPTION
Closes #294

## 背景

main ブランチ CI が 2 週間連続で失敗していたが Pushover 通知が一度も届いておらず無通知放置になっていた。実測したところ:

- Repository Secrets に `PUSHOVER_USER_KEY` / `PUSHOVER_API_TOKEN` が **未登録**（`gh secret list` で確認）
- 既存の `notify` job は `curl -sf` で空文字 token を送信して exit 22 → job 自体が failure
- 通知役自身が failure になり、その失敗を伝える経路がない構造的欠陥

run 24551149088 のログで env が空のまま curl 実行 → exit 22 を確認済み。

## 変更点

### `.github/workflows/ci.yml`

- `needs` を `[lint-and-build, test, deploy-stg, e2e-stg, deploy-prod, e2e-prod]` 全段に拡張（従来は e2e-stg/deploy-prod/e2e-prod の 3 つのみ）
- `result` step で各 job の result を env 経由で評価（RW-024 対策で `${{ }}` を bash に直接展開しない）
- 失敗 job 名を列挙、短縮 SHA・commit title・Run URL を `payload` step で構築し $GITHUB_OUTPUT に格納
- Pushover step は `continue-on-error: true` + secrets 空チェック + HTTP code チェック
- **Pushover が失敗 or secrets 未設定の場合**、`gh issue create --label ci-failure` で自動起票するフォールバック step を追加（同 SHA で既に open issue があれば再起票しない dedup あり）
- notify job 自体は最後の step まで通るので必ず success（通知役自身の落ち抑止）

### `docs/deploy.md`

- 「CI 通知 (Pushover)」セクション追加
- `gh secret set PUSHOVER_USER_KEY` / `PUSHOVER_API_TOKEN` の登録手順
- 動作確認手順（既存失敗 run の rerun + Issue 起票確認）

## AC 検証

| # | AC | 状態 |
|---|---|---|
| 1 | notify job が任意の前段 failure で必ず発火 | PASS — `needs` 6 job 化 + `if: always()` |
| 2 | 失敗時に Pushover 着信を実測 | **ユーザー作業待ち**: secrets 登録後に既存失敗 run を rerun して実測必要 |
| 3 | PUSHOVER_* secrets 存在確認 | FAIL（**未登録を実測**）→ docs に登録手順を追加。本 PR merge 後に手動登録要 |
| 4 | 本修正以降の CI で必ず通知される | PASS — Pushover 失敗時の Issue フォールバックで二重防御済み |

## 統合ジャーニーAC

Issue #294 で「CI / GitHub Actions workflow の通知信頼性向上であり、エンドユーザー操作フローへの影響なし」として例外適用済み。

## ユーザー作業（merge 後）

1. Pushover で `User Key` / `API Token` を取得（または既存の値を使用）
2. ```bash
   gh secret set PUSHOVER_USER_KEY --repo miyashita337/convert-service
   gh secret set PUSHOVER_API_TOKEN --repo miyashita337/convert-service
   ```
3. 既存失敗 run を rerun して着信確認: `gh run rerun <RUN_ID> --job notify`

secrets 未登録のままでも、CI 失敗時に `ci-failure` ラベル付き Issue が自動起票されるので無通知放置は発生しない。