### PR TITLE
feat: SEO MVP キーワード選定 subagent (Closes #323)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ dist/
 .env
 .env.local
 .env.*.local
+.env.seo
+tools/seo-pipeline/.env.seo
+
+# SEO pipeline 出力 (runtime artifact、再生成可能)
+docs/articles/seo-drafts/
 .wrangler/
 .dev.vars
 *.tsbuildinfo

--- a/tools/seo-pipeline/.env.seo.example
+++ b/tools/seo-pipeline/.env.seo.example
@@ -1,0 +1,15 @@
+# SEO MVP pipeline 認証情報 (本ファイルはテンプレ。実値は .env.seo にコピーして使う)
+#
+# RW-014 教訓: tools/team_salary/.env と分離。広域 deny で巻き込まれない位置に置く。
+# .env.seo は .gitignore 対象 (リポ追加禁止)
+
+# --- Google Search Console (任意) ---
+# 未設定または認証エラー時は手動 seed フォールバックで動作続行
+GSC_OAUTH_CLIENT_ID=
+GSC_OAUTH_CLIENT_SECRET=
+GSC_REFRESH_TOKEN=
+GSC_SITE_URL=https://quickconv.cc/
+
+# --- 予算 cap (推奨) ---
+# 本スクリプトはトークン消費しないが、後続パイプライン全体の予算指標として尊重する
+MAX_CLAUDE_TOKENS_PER_RUN=200000

--- a/tools/seo-pipeline/README.md
+++ b/tools/seo-pipeline/README.md
@@ -1,0 +1,80 @@
+# SEO Pipeline — MVP
+
+QuickConv SEO 集客自動化 (Epic #320) の MVP パイプライン。
+
+## モジュール一覧
+
+| ファイル | Issue | 役割 |
+|---|---|---|
+| `keyword-research.mjs` | #323 | キーワード選定 (Search Console + 手動 seed) |
+| (未実装) `competition.mjs` | #324 | 競合分析 (Prompt Injection サンドボックス) |
+| (未実装) `outline.mjs` | #325 | 構成案生成 + 3段オーケストレーター |
+| (未実装) `publish-draft.mjs` | #326 | note/Qiita 下書き接続 + DOMPurify |
+
+## keyword-research.mjs
+
+### 使い方
+
+```bash
+# 最小実行 (手動 seed のみ)
+node tools/seo-pipeline/keyword-research.mjs --seed "WebP 変換"
+
+# 複数 seed + 出力先指定
+node tools/seo-pipeline/keyword-research.mjs --seed "WebP 変換" --seed "AVIF 変換" --out docs/articles/seo-drafts
+
+# dry-run (ファイル書き出さず stdout に JSON 出力)
+node tools/seo-pipeline/keyword-research.mjs --seed "WebP 変換" --dry-run
+```
+
+### 出力スキーマ
+
+```jsonc
+{
+  "version": "1",
+  "generated_at": "2026-05-13T01:23:45.000Z",
+  "meta": {
+    "fallback": true,           // Search Console 認証エラー時 true
+    "seeds": ["WebP 変換"],
+    "source": "search-console" | "manual-seed",
+    "warning": "..."            // フォールバック理由 (任意)
+  },
+  "keywords": [
+    {
+      "keyword": "WebP 変換",
+      "score": 0,
+      "source": "seed" | "expansion" | "search-console",
+      "search_volume": null,    // GSC データある場合のみ
+      "ctr": null               // GSC データある場合のみ
+    }
+  ]
+}
+```
+
+### Search Console API 設定 (任意)
+
+`.env.seo.example` をコピーして `.env.seo` を作成し、Google Cloud Console で OAuth クライアントを発行:
+
+```bash
+cp tools/seo-pipeline/.env.seo.example tools/seo-pipeline/.env.seo
+# 編集して GSC_OAUTH_CLIENT_ID / SECRET / REFRESH_TOKEN / SITE_URL を設定
+```
+
+未設定または認証エラー時は手動 seed のみで動作続行 (`meta.fallback=true`)。
+
+### セキュリティ
+
+- `.env.seo` は `.gitignore` 対象 (リポ追加禁止)
+- `tools/team_salary/.env` とは分離 (RW-014 教訓)
+- ログには認証情報をマスク表示 (`maskSecret`)
+
+### テスト
+
+```bash
+node --test tools/seo-pipeline/__tests__/keyword-research.test.mjs
+```
+
+### 関連 RW
+
+- RW-014: `.env.seo` 分離で広域 deny 巻き込みを未然回避
+- RW-037: subagent 起動原則 (本 CLI は subagent 起動を強制しない)
+- RW-021: 壊れた関数呼び出し / ハードコード回避 (CLI 引数で seed 受取)

--- a/tools/seo-pipeline/__tests__/keyword-research.test.mjs
+++ b/tools/seo-pipeline/__tests__/keyword-research.test.mjs
@@ -1,0 +1,268 @@
+// node --test tools/seo-pipeline/__tests__/keyword-research.test.mjs
+//
+// Issue #323 AC のユニットテスト:
+// - parseArgs: 空 seed エラー、複数 seed、不正引数
+// - expandSeed: 日英判定、最大バリアント数
+// - computeScore: 境界値 (impressions=0, position<=0, ctr 無し)
+// - validateKeywordsOutput: 必須フィールド
+// - generateKeywords: フォールバック動作、GSC データ統合、空 seed エラー
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseArgs,
+  expandSeed,
+  computeScore,
+  validateKeywordsOutput,
+  generateKeywords,
+  loadEnvSeo,
+} from "../keyword-research.mjs";
+
+/* -------------------------------------------------------------------------- */
+/* parseArgs                                                                  */
+/* -------------------------------------------------------------------------- */
+
+test("parseArgs: 空 seed なしの場合はエラー", () => {
+  assert.throws(() => parseArgs([]), /at least one --seed is required/);
+});
+
+test("parseArgs: 単一 seed", () => {
+  const r = parseArgs(["--seed", "WebP 変換"]);
+  assert.deepEqual(r.seeds, ["WebP 変換"]);
+  assert.equal(r.outDir, "docs/articles/seo-drafts");
+  assert.equal(r.dryRun, false);
+});
+
+test("parseArgs: 複数 seed + out + dry-run", () => {
+  const r = parseArgs(["--seed", "A", "--seed", "B", "--out", "custom", "--dry-run"]);
+  assert.deepEqual(r.seeds, ["A", "B"]);
+  assert.equal(r.outDir, "custom");
+  assert.equal(r.dryRun, true);
+});
+
+test("parseArgs: --seed の値欠落でエラー", () => {
+  assert.throws(() => parseArgs(["--seed"]), /--seed requires a value/);
+});
+
+test("parseArgs: 不明引数でエラー", () => {
+  assert.throws(() => parseArgs(["--unknown"]), /Unknown argument/);
+});
+
+test("parseArgs: --help でショートサーキット", () => {
+  const r = parseArgs(["--help"]);
+  assert.equal(r.help, true);
+});
+
+/* -------------------------------------------------------------------------- */
+/* expandSeed                                                                 */
+/* -------------------------------------------------------------------------- */
+
+test("expandSeed: 空文字は空配列", () => {
+  assert.deepEqual(expandSeed(""), []);
+  assert.deepEqual(expandSeed("   "), []);
+});
+
+test("expandSeed: 日本語 seed で seed + 修飾語のバリアント", () => {
+  const r = expandSeed("WebP 変換");
+  assert.ok(r.length >= 3, `expected >=3 variants, got ${r.length}`);
+  assert.equal(r[0], "WebP 変換");
+  assert.ok(r.some((v) => v.includes("方法") || v.includes("やり方") || v.includes("無料")));
+});
+
+test("expandSeed: 英語 seed で英語修飾語", () => {
+  const r = expandSeed("webp converter");
+  assert.ok(r.length >= 3);
+  assert.equal(r[0], "webp converter");
+  assert.ok(r.some((v) => v.includes("free") || v.includes("online") || v.includes("tool")));
+});
+
+test("expandSeed: maxVariants 上限を尊重", () => {
+  const r = expandSeed("WebP 変換", { maxVariants: 3 });
+  // seed 自身 + 最大 maxVariants 個 = 最大 maxVariants+1
+  assert.ok(r.length <= 4, `expected <=4, got ${r.length}`);
+});
+
+/* -------------------------------------------------------------------------- */
+/* computeScore — 境界値                                                       */
+/* -------------------------------------------------------------------------- */
+
+test("computeScore: impressions=0 → 0", () => {
+  assert.equal(computeScore({ impressions: 0, ctr: 0.1, position: 5 }), 0);
+});
+
+test("computeScore: position=0 → 0", () => {
+  assert.equal(computeScore({ impressions: 100, ctr: 0.1, position: 0 }), 0);
+});
+
+test("computeScore: position<0 → 0", () => {
+  assert.equal(computeScore({ impressions: 100, ctr: 0.1, position: -1 }), 0);
+});
+
+test("computeScore: impressions=NaN → 0", () => {
+  assert.equal(computeScore({ impressions: NaN, ctr: 0.1, position: 5 }), 0);
+});
+
+test("computeScore: ctr 無しでも score 計算可能", () => {
+  // 100 * (1/5) * (1 + 0*10) = 20
+  assert.equal(computeScore({ impressions: 100, position: 5 }), 20);
+});
+
+test("computeScore: ctr 込みでスコア増", () => {
+  // 100 * (1/5) * (1 + 0.1*10) = 20 * 2 = 40
+  assert.equal(computeScore({ impressions: 100, ctr: 0.1, position: 5 }), 40);
+});
+
+test("computeScore: position が高い (低い順位) ほど低スコア", () => {
+  const high = computeScore({ impressions: 100, position: 1 });
+  const low = computeScore({ impressions: 100, position: 50 });
+  assert.ok(high > low, `expected position=1 > position=50, got ${high} vs ${low}`);
+});
+
+/* -------------------------------------------------------------------------- */
+/* validateKeywordsOutput                                                     */
+/* -------------------------------------------------------------------------- */
+
+test("validateKeywordsOutput: 正常な payload はエラー 0", () => {
+  const ok = {
+    version: "1",
+    generated_at: "2026-05-13T00:00:00Z",
+    meta: { fallback: false, seeds: ["x"], source: "manual-seed" },
+    keywords: [{ keyword: "x", score: 1.5, source: "seed" }],
+  };
+  assert.deepEqual(validateKeywordsOutput(ok), []);
+});
+
+test("validateKeywordsOutput: 必須フィールド欠落を検出", () => {
+  const errs = validateKeywordsOutput({});
+  assert.ok(errs.length > 0);
+  assert.ok(errs.some((e) => e.includes("version")));
+  assert.ok(errs.some((e) => e.includes("keywords")));
+});
+
+test("validateKeywordsOutput: keywords 内の型ミスを検出", () => {
+  const errs = validateKeywordsOutput({
+    version: "1",
+    generated_at: "x",
+    meta: { fallback: false, seeds: [], source: "x" },
+    keywords: [{ keyword: "", score: "not-number", source: 123 }],
+  });
+  assert.ok(errs.some((e) => e.includes("keyword")));
+  assert.ok(errs.some((e) => e.includes("score")));
+  assert.ok(errs.some((e) => e.includes("source")));
+});
+
+test("validateKeywordsOutput: root が非オブジェクトはエラー", () => {
+  assert.ok(validateKeywordsOutput(null).length > 0);
+  assert.ok(validateKeywordsOutput("string").length > 0);
+});
+
+/* -------------------------------------------------------------------------- */
+/* generateKeywords                                                           */
+/* -------------------------------------------------------------------------- */
+
+test("generateKeywords: 空 seeds でエラー", async () => {
+  await assert.rejects(generateKeywords({ seeds: [] }), /non-empty array/);
+});
+
+test("generateKeywords: 空文字のみの seeds でエラー", async () => {
+  await assert.rejects(generateKeywords({ seeds: ["   ", ""] }), /empty strings/);
+});
+
+test("generateKeywords: 認証情報なし → フォールバック動作", async () => {
+  const result = await generateKeywords({
+    seeds: ["WebP 変換"],
+    env: {},
+    gscFetcher: async () => null,
+  });
+  assert.equal(result.meta.fallback, true);
+  assert.equal(result.meta.source, "manual-seed");
+  assert.ok(result.keywords.length >= 3, `expected >=3 keywords, got ${result.keywords.length}`);
+  // seed が含まれる
+  assert.ok(result.keywords.some((k) => k.keyword === "WebP 変換" && k.source === "seed"));
+});
+
+test("generateKeywords: GSC fetcher が例外を投げてもフォールバックで続行", async () => {
+  const result = await generateKeywords({
+    seeds: ["WebP 変換"],
+    env: { GSC_OAUTH_CLIENT_ID: "x", GSC_OAUTH_CLIENT_SECRET: "y", GSC_REFRESH_TOKEN: "z", GSC_SITE_URL: "https://example.com" },
+    gscFetcher: async () => {
+      throw new Error("network down");
+    },
+  });
+  assert.equal(result.meta.fallback, true);
+  assert.equal(result.meta.warning, "network down");
+  assert.ok(result.keywords.length >= 3);
+});
+
+test("generateKeywords: GSC データありで search-console source + score", async () => {
+  const result = await generateKeywords({
+    seeds: ["WebP"],
+    env: {},
+    gscFetcher: async () => [
+      { keys: ["WebP 変換 無料"], impressions: 1000, ctr: 0.05, position: 3 },
+      { keys: ["WebP"], impressions: 500, ctr: 0.1, position: 1 },
+    ],
+  });
+  assert.equal(result.meta.fallback, false);
+  assert.equal(result.meta.source, "search-console");
+  // GSC からのキーワードが取り込まれている
+  const gscKw = result.keywords.find((k) => k.keyword === "WebP 変換 無料");
+  assert.ok(gscKw);
+  assert.ok(gscKw.score > 0);
+  assert.equal(gscKw.search_volume, 1000);
+  assert.equal(gscKw.ctr, 0.05);
+});
+
+test("generateKeywords: seed 重複は除外される", async () => {
+  const result = await generateKeywords({
+    seeds: ["WebP", "WebP", "  WebP  "],
+    env: {},
+    gscFetcher: async () => null,
+  });
+  assert.deepEqual(result.meta.seeds, ["WebP"]);
+});
+
+test("generateKeywords: keywords が score 降順で sort される", async () => {
+  const result = await generateKeywords({
+    seeds: ["WebP"],
+    env: {},
+    gscFetcher: async () => [
+      { keys: ["low"], impressions: 10, ctr: 0, position: 10 },
+      { keys: ["high"], impressions: 1000, ctr: 0.1, position: 1 },
+      { keys: ["mid"], impressions: 100, ctr: 0.05, position: 3 },
+    ],
+  });
+  // score 降順 (seed 由来は score=0 で末尾)
+  const scores = result.keywords.map((k) => k.score);
+  for (let i = 1; i < scores.length; i++) {
+    assert.ok(scores[i - 1] >= scores[i], `not sorted desc: ${JSON.stringify(scores)}`);
+  }
+});
+
+test("generateKeywords: GSC reachable but 0 rows → fallback=false, primary source", async () => {
+  const result = await generateKeywords({
+    seeds: ["WebP"],
+    env: {},
+    gscFetcher: async () => [],
+  });
+  assert.equal(result.meta.fallback, false);
+  assert.equal(result.meta.source, "search-console");
+  // それでも seed expansion は含まれる
+  assert.ok(result.keywords.length >= 3);
+});
+
+/* -------------------------------------------------------------------------- */
+/* loadEnvSeo                                                                 */
+/* -------------------------------------------------------------------------- */
+
+test("loadEnvSeo: 存在しないファイルは空オブジェクト", () => {
+  const r = loadEnvSeo("/nonexistent/path/.env.seo");
+  assert.deepEqual(r, {});
+});
+
+test("loadEnvSeo: example ファイルをパース可能", () => {
+  const r = loadEnvSeo(new URL("../.env.seo.example", import.meta.url).pathname);
+  assert.equal(r.GSC_SITE_URL, "https://quickconv.cc/");
+  assert.equal(r.MAX_CLAUDE_TOKENS_PER_RUN, "200000");
+});

--- a/tools/seo-pipeline/keyword-research.mjs
+++ b/tools/seo-pipeline/keyword-research.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+// SEO MVP: キーワード選定 subagent (Phase A - Search Console + 手動 seed)
+//
+// 使い方:
+//   node tools/seo-pipeline/keyword-research.mjs --seed "WebP 変換" [--seed "AVIF 変換"] [--out <dir>]
+//
+// 認証 (任意): .env.seo の以下を読み込む
+//   GSC_OAUTH_CLIENT_ID, GSC_OAUTH_CLIENT_SECRET, GSC_REFRESH_TOKEN, GSC_SITE_URL
+//   認証エラー / 未設定時は手動 seed フォールバックで続行 (meta.fallback=true)
+//
+// 予算 cap (任意): MAX_CLAUDE_TOKENS_PER_RUN (本スクリプトはトークン消費しないが、生成上限の指標として尊重)
+//
+// 出力: <out>/<YYYY-MM-DD>/keywords.json (default <out>=docs/articles/seo-drafts)
+
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, "../..");
+
+/* -------------------------------------------------------------------------- */
+/* env loader (.env.seo)                                                      */
+/* -------------------------------------------------------------------------- */
+
+export function loadEnvSeo(filePath = resolve(PROJECT_ROOT, "tools/seo-pipeline/.env.seo")) {
+  if (!existsSync(filePath)) return {};
+  const raw = readFileSync(filePath, "utf-8");
+  const out = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* CLI argument parser                                                        */
+/* -------------------------------------------------------------------------- */
+
+export function parseArgs(argv) {
+  const seeds = [];
+  let outDir = "docs/articles/seo-drafts";
+  let dryRun = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--seed") {
+      const v = argv[++i];
+      if (!v) throw new Error("--seed requires a value");
+      seeds.push(v);
+    } else if (a === "--out") {
+      const v = argv[++i];
+      if (!v) throw new Error("--out requires a value");
+      outDir = v;
+    } else if (a === "--dry-run") {
+      dryRun = true;
+    } else if (a === "--help" || a === "-h") {
+      return { help: true };
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  if (seeds.length === 0) {
+    throw new Error("at least one --seed is required");
+  }
+  return { seeds, outDir, dryRun };
+}
+
+/* -------------------------------------------------------------------------- */
+/* seed expansion (manual fallback)                                           */
+/* -------------------------------------------------------------------------- */
+
+const JP_MODIFIERS = [
+  "方法",
+  "やり方",
+  "無料",
+  "サイト",
+  "オンライン",
+  "コツ",
+  "アプリ",
+  "おすすめ",
+];
+
+const EN_MODIFIERS = [
+  "free",
+  "online",
+  "tool",
+  "best",
+  "how to",
+  "convert",
+];
+
+export function expandSeed(seed, { maxVariants = 8 } = {}) {
+  const trimmed = seed.trim();
+  if (!trimmed) return [];
+  const isJa = /[぀-ヿ一-龯]/.test(trimmed);
+  const modifiers = isJa ? JP_MODIFIERS : EN_MODIFIERS;
+  const variants = new Set();
+  variants.add(trimmed);
+  for (const m of modifiers) {
+    if (variants.size >= maxVariants + 1) break;
+    variants.add(`${trimmed} ${m}`);
+  }
+  return Array.from(variants);
+}
+
+/* -------------------------------------------------------------------------- */
+/* scoring                                                                    */
+/* -------------------------------------------------------------------------- */
+
+// Search Console データがあれば impressions × position-weighted CTR でスコア。
+// position が低い (1 に近い) ほど高スコア。CTR データなしの場合は impressions のみ。
+// フォールバック時は変動なし (0.0)。境界値: impressions=0 → score=0、position<=0 → score=0。
+export function computeScore({ impressions = 0, ctr = 0, position = 0 }) {
+  if (!Number.isFinite(impressions) || impressions <= 0) return 0;
+  if (!Number.isFinite(position) || position <= 0) return 0;
+  const positionWeight = 1 / position;
+  const ctrSafe = Number.isFinite(ctr) && ctr > 0 ? ctr : 0;
+  // 簡易な合成スコア。impressions × position_weight × (1 + ctr*10)
+  const score = impressions * positionWeight * (1 + ctrSafe * 10);
+  // 小数 4 桁丸め
+  return Math.round(score * 10000) / 10000;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Search Console API client (OAuth2 refresh + searchAnalytics.query)          */
+/* -------------------------------------------------------------------------- */
+
+const GSC_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GSC_QUERY_URL = (siteUrl) =>
+  `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(
+    siteUrl,
+  )}/searchAnalytics/query`;
+
+async function refreshAccessToken({ clientId, clientSecret, refreshToken }, { timeoutMs = 10000 } = {}) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(GSC_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+        grant_type: "refresh_token",
+      }).toString(),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`token refresh failed: HTTP ${res.status}`);
+    }
+    const data = await res.json();
+    if (!data.access_token) throw new Error("token refresh returned no access_token");
+    return data.access_token;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export async function fetchSearchConsoleQueries(env, { timeoutMs = 15000 } = {}) {
+  const { GSC_OAUTH_CLIENT_ID, GSC_OAUTH_CLIENT_SECRET, GSC_REFRESH_TOKEN, GSC_SITE_URL } = env;
+  if (!GSC_OAUTH_CLIENT_ID || !GSC_OAUTH_CLIENT_SECRET || !GSC_REFRESH_TOKEN || !GSC_SITE_URL) {
+    return null;
+  }
+  const accessToken = await refreshAccessToken({
+    clientId: GSC_OAUTH_CLIENT_ID,
+    clientSecret: GSC_OAUTH_CLIENT_SECRET,
+    refreshToken: GSC_REFRESH_TOKEN,
+  });
+  const today = new Date();
+  const startDate = new Date(today);
+  startDate.setDate(startDate.getDate() - 90);
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(GSC_QUERY_URL(GSC_SITE_URL), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        startDate: fmt(startDate),
+        endDate: fmt(today),
+        dimensions: ["query"],
+        rowLimit: 100,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`searchAnalytics.query failed: HTTP ${res.status}`);
+    }
+    const data = await res.json();
+    return Array.isArray(data.rows) ? data.rows : [];
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* schema validation                                                          */
+/* -------------------------------------------------------------------------- */
+
+export function validateKeywordsOutput(obj) {
+  const errors = [];
+  if (!obj || typeof obj !== "object") {
+    return ["root must be an object"];
+  }
+  if (obj.version !== "1") errors.push("version must be '1'");
+  if (typeof obj.generated_at !== "string") errors.push("generated_at must be a string");
+  if (!obj.meta || typeof obj.meta !== "object") {
+    errors.push("meta must be an object");
+  } else {
+    if (typeof obj.meta.fallback !== "boolean") errors.push("meta.fallback must be boolean");
+    if (!Array.isArray(obj.meta.seeds)) errors.push("meta.seeds must be an array");
+    if (typeof obj.meta.source !== "string") errors.push("meta.source must be a string");
+  }
+  if (!Array.isArray(obj.keywords)) {
+    errors.push("keywords must be an array");
+  } else {
+    obj.keywords.forEach((k, i) => {
+      if (!k || typeof k !== "object") {
+        errors.push(`keywords[${i}] must be an object`);
+        return;
+      }
+      if (typeof k.keyword !== "string" || !k.keyword.trim()) {
+        errors.push(`keywords[${i}].keyword must be a non-empty string`);
+      }
+      if (typeof k.score !== "number" || !Number.isFinite(k.score)) {
+        errors.push(`keywords[${i}].score must be a finite number`);
+      }
+      if (typeof k.source !== "string") {
+        errors.push(`keywords[${i}].source must be a string`);
+      }
+    });
+  }
+  return errors;
+}
+
+/* -------------------------------------------------------------------------- */
+/* core pipeline                                                              */
+/* -------------------------------------------------------------------------- */
+
+export async function generateKeywords({ seeds, env = {}, gscFetcher = fetchSearchConsoleQueries, now = () => new Date() }) {
+  if (!Array.isArray(seeds) || seeds.length === 0) {
+    throw new Error("seeds must be a non-empty array");
+  }
+  const dedupedSeeds = Array.from(new Set(seeds.map((s) => s.trim()).filter(Boolean)));
+  if (dedupedSeeds.length === 0) {
+    throw new Error("seeds contained only empty strings");
+  }
+
+  let gscRows = null;
+  let fallback = false;
+  let source = "manual-seed";
+  let warning = null;
+
+  try {
+    gscRows = await gscFetcher(env);
+    if (gscRows && gscRows.length > 0) {
+      source = "search-console";
+    } else if (gscRows && gscRows.length === 0) {
+      // GSC reachable but no data, still primary
+      source = "search-console";
+    } else {
+      fallback = true;
+    }
+  } catch (err) {
+    fallback = true;
+    warning = err.message;
+  }
+
+  const merged = new Map();
+
+  // seed-derived candidates
+  for (const seed of dedupedSeeds) {
+    for (const variant of expandSeed(seed)) {
+      if (!merged.has(variant)) {
+        merged.set(variant, {
+          keyword: variant,
+          score: 0,
+          source: variant === seed ? "seed" : "expansion",
+        });
+      }
+    }
+  }
+
+  // GSC-derived candidates
+  if (gscRows && gscRows.length > 0) {
+    for (const row of gscRows) {
+      const kw = Array.isArray(row.keys) ? row.keys[0] : null;
+      if (!kw || typeof kw !== "string") continue;
+      const score = computeScore({
+        impressions: row.impressions,
+        ctr: row.ctr,
+        position: row.position,
+      });
+      const existing = merged.get(kw);
+      if (existing) {
+        existing.score = Math.max(existing.score, score);
+        existing.search_volume = row.impressions;
+        existing.ctr = row.ctr;
+      } else {
+        merged.set(kw, {
+          keyword: kw,
+          score,
+          source: "search-console",
+          search_volume: row.impressions,
+          ctr: row.ctr,
+        });
+      }
+    }
+  }
+
+  const keywords = Array.from(merged.values()).sort((a, b) => b.score - a.score);
+
+  return {
+    version: "1",
+    generated_at: now().toISOString(),
+    meta: {
+      fallback,
+      seeds: dedupedSeeds,
+      source,
+      ...(warning ? { warning } : {}),
+    },
+    keywords,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* output writer                                                              */
+/* -------------------------------------------------------------------------- */
+
+export function writeKeywordsOutput(payload, outDir, { now = () => new Date() } = {}) {
+  const day = now().toISOString().slice(0, 10);
+  const dir = resolve(PROJECT_ROOT, outDir, day);
+  mkdirSync(dir, { recursive: true });
+  const filePath = resolve(dir, "keywords.json");
+  writeFileSync(filePath, JSON.stringify(payload, null, 2) + "\n", "utf-8");
+  return filePath;
+}
+
+/* -------------------------------------------------------------------------- */
+/* CLI entry point                                                            */
+/* -------------------------------------------------------------------------- */
+
+function maskSecret(v) {
+  if (!v) return "(unset)";
+  if (v.length <= 6) return "***";
+  return `${v.slice(0, 3)}…${v.slice(-2)}`;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  let parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (err) {
+    console.error(`ERROR: ${err.message}`);
+    console.error("Usage: node tools/seo-pipeline/keyword-research.mjs --seed <kw> [--seed <kw>...] [--out <dir>] [--dry-run]");
+    process.exit(1);
+  }
+  if (parsed.help) {
+    console.log("Usage: node tools/seo-pipeline/keyword-research.mjs --seed <kw> [--seed <kw>...] [--out <dir>] [--dry-run]");
+    process.exit(0);
+  }
+  const fileEnv = loadEnvSeo();
+  const env = { ...fileEnv, ...process.env };
+
+  const maxBudget = parseInt(env.MAX_CLAUDE_TOKENS_PER_RUN || "0", 10);
+  console.error(
+    JSON.stringify({
+      level: "info",
+      ts: new Date().toISOString(),
+      msg: "keyword-research start",
+      seeds: parsed.seeds,
+      out: parsed.outDir,
+      gsc_client: maskSecret(env.GSC_OAUTH_CLIENT_ID),
+      gsc_site: env.GSC_SITE_URL || "(unset)",
+      max_budget_tokens: maxBudget || null,
+    }),
+  );
+
+  let payload;
+  try {
+    payload = await generateKeywords({ seeds: parsed.seeds, env });
+  } catch (err) {
+    console.error(JSON.stringify({ level: "error", ts: new Date().toISOString(), msg: err.message }));
+    process.exit(2);
+  }
+
+  const errs = validateKeywordsOutput(payload);
+  if (errs.length > 0) {
+    console.error(JSON.stringify({ level: "error", ts: new Date().toISOString(), msg: "schema validation failed", errors: errs }));
+    process.exit(3);
+  }
+
+  if (parsed.dryRun) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const filePath = writeKeywordsOutput(payload, parsed.outDir);
+  console.error(
+    JSON.stringify({
+      level: "info",
+      ts: new Date().toISOString(),
+      msg: "keyword-research done",
+      file: filePath,
+      keywords_count: payload.keywords.length,
+      fallback: payload.meta.fallback,
+      source: payload.meta.source,
+    }),
+  );
+}
+
+// Run only when executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## 概要

Epic #320 / Sub #323 - MVP パイプラインの **キーワード選定 subagent** を実装。

Search Console webmasters/v3 API (read-only) + 手動 seed フォールバックの 2段構成。動画通り Ahrefs MCP (\$99/月) は ADR-006 通り MVP に含めず、Search Console + 手動 seed を第一選択にした。

## 実装内容

- `tools/seo-pipeline/keyword-research.mjs` - CLI (約 320 行、依存 0)
- `tools/seo-pipeline/.env.seo.example` - 認証情報テンプレ
- `tools/seo-pipeline/README.md` - 使い方・スキーマ・セキュリティ
- `tools/seo-pipeline/__tests__/keyword-research.test.mjs` - node:test 31 ケース

## 設計判断

- **外部依存ゼロ**: zod の代わりに手書き validator、googleapis の代わりに fetch + OAuth2 refresh で Search Console API を直叩き
- **フォールバック優先**: 認証情報未設定 / 401 / タイムアウト / ネットワーク失敗 → `meta.fallback=true` で動作続行
- **日英 seed 自動判定**: ひらカナ漢字を検出して JP_MODIFIERS / EN_MODIFIERS を切替
- **score 降順 sort**: position-weighted CTR × impressions (フォールバック時は seed expansion なので 0)

## セキュリティ

- \`.env.seo\` を \`.gitignore\` 対象 (RW-014 教訓: \`team_salary/.env\` と分離)
- 出力 \`docs/articles/seo-drafts/\` も \`.gitignore\` (runtime artifact、再生成可能)
- ログは認証情報マスク (\`maskSecret\`)
- API 呼び出しは AbortController で 10-15s timeout

## 統合ジャーニーAC 検証

| AC | 期待 | 実測 | 判定 |
|---|---|---|---|
| AC-1 keywords >= 3 | >= 3 | 9件 | ✅ PASS |
| AC-2 認証エラー時 fallback=true | true | true | ✅ PASS |

検証コマンド:
\`\`\`bash
node tools/seo-pipeline/keyword-research.mjs --seed "WebP 変換"
jq '.keywords | length' docs/articles/seo-drafts/\$(date +%Y-%m-%d)/keywords.json  # => 9
jq '.meta.fallback'    docs/articles/seo-drafts/\$(date +%Y-%m-%d)/keywords.json  # => true
\`\`\`

## 受入基準

- [x] \`tools/seo-pipeline/keyword-research.mjs\` 実装
- [x] Search Console API 連携 (read-only スコープ)
- [x] 手動 seed フォールバック実装
- [x] keywords.json スキーマ定義 (zod 推奨 → 手書き validator)
- [x] ユニットテスト (スコア計算境界値、空 seed エラー他 31 ケース)

## テスト結果

\`\`\`
ℹ tests 31
ℹ pass 31
ℹ fail 0
ℹ duration_ms 111.785167
\`\`\`

## 関連

- Parent Epic: #320
- 関連 RW: RW-014 (env 分離), RW-037 (subagent 起動原則), RW-021 (ハードコード回避)
- 後続 Issue: #324 競合分析, #325 構成案生成, #326 publish-draft.mjs

Closes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * SEO パイプライン MVP を追加。キーワード調査ツールが利用可能になりました。Google Search Console との連携により、検索データに基づくキーワードスコアリングが実現されます。

* **ドキュメント**
  * SEO パイプラインの使用方法、設定手順、スキーマ仕様についてのドキュメントを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyashita337/convert-service/pull/335)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->