### PR TITLE
fix: wrangler pages deploy に ASCII commit message を明示 (Closes #344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler pages deploy apps/web/out --project-name quickconv-web --branch staging
+        # --commit-message/--commit-hash を ASCII で明示。未指定だと wrangler が
+        # 日本語の HEAD commit message を渡し Cloudflare API が UTF-8 検証で落ちる (#344, code:8000111)
+        run: npx wrangler pages deploy apps/web/out --project-name quickconv-web --branch staging --commit-hash "$GITHUB_SHA" --commit-message "deploy $GITHUB_SHA"
       - name: Deploy API to Workers (staging)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -197,7 +199,8 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler pages deploy apps/web/out --project-name quickconv-web
+        # --commit-message/--commit-hash を ASCII で明示 (#344, code:8000111)
+        run: npx wrangler pages deploy apps/web/out --project-name quickconv-web --commit-hash "$GITHUB_SHA" --commit-message "deploy $GITHUB_SHA"
       - name: Deploy API to Workers (production)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## 目的
`deploy-stg` / `deploy-prod` の `wrangler pages deploy` が Cloudflare Pages API の UTF-8 検証 (`code:8000111`) で連続失敗していた問題を解消する。これにより派生して自動起票された #346 の deploy-stg 失敗も解消する。

## 根本原因
`wrangler pages deploy` は `--commit-message` 未指定時に HEAD の commit message を自動取得して Cloudflare に渡す。本リポは日本語コミットメッセージ（JP+EN+記号混在）を使うため、Cloudflare 側の commit message validation が `Invalid commit message, it must be a valid UTF-8 string` を返し、ファイルアップロード成功後の deployment 作成リクエストで落ちていた。

## 変更点
- `deploy-stg` / `deploy-prod` の `wrangler pages deploy` に `--commit-hash "$GITHUB_SHA"` と `--commit-message "deploy $GITHUB_SHA"`（ASCII 安全）を明示
- `GITHUB_SHA` は GitHub Actions のデフォルト環境変数

## テスト方法
- [x] `actionlint` で YAML 構文 PASS（本変更箇所のエラーなし）
- [ ] main マージ後、`deploy-stg` job が PASS することを CI で確認（#344 / #346 の AC）

## 関連
- Closes #344
- Refs #346（deploy-stg 失敗部分は本PRで解消。Pushover secret 未設定の通知部分は別途リポ設定が必要）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインのデプロイメント処理を改善し、stagingおよびproduction環境へのデプロイメント時にコミット情報を明示的に記録するよう変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->