### PR TITLE
fix: Stripe Price ID を test/live モードで自動切替 (Closes #343)

### DIFF
--- a/apps/api/src/__tests__/checkout.test.ts
+++ b/apps/api/src/__tests__/checkout.test.ts
@@ -10,6 +10,8 @@ vi.mock("../services/stripe", () => ({
   },
   isValidPlanId: (id: string) => ["pass_7d", "pass_30d", "plus_monthly", "pro_monthly"].includes(id),
   resolveStripePriceId: vi.fn().mockReturnValue("price_test_123"),
+  isTestModeEnv: (env: { STRIPE_SECRET_KEY?: string }) =>
+    env.STRIPE_SECRET_KEY?.startsWith("sk_test") ?? false,
 }));
 
 import checkout from "../routes/checkout";
@@ -163,14 +165,14 @@ describe("checkout /", () => {
     const app = createApp({ email: "user@example.com", stripeCustomerId: null, plan: "free" });
     await postCheckout(app, { planId: "plus_monthly" }, env);
     const { resolveStripePriceId } = await import("../services/stripe");
-    expect(resolveStripePriceId).toHaveBeenCalledWith("plus_monthly", "jpy");
+    expect(resolveStripePriceId).toHaveBeenCalledWith("plus_monthly", "jpy", true);
   });
 
   it("respects usd currency", async () => {
     const app = createApp({ email: "user@example.com", stripeCustomerId: null, plan: "free" });
     await postCheckout(app, { planId: "plus_monthly", currency: "usd" }, env);
     const { resolveStripePriceId } = await import("../services/stripe");
-    expect(resolveStripePriceId).toHaveBeenCalledWith("plus_monthly", "usd");
+    expect(resolveStripePriceId).toHaveBeenCalledWith("plus_monthly", "usd", true);
   });
 
   it("returns 429 when rate limit exceeded", async () => {

--- a/apps/api/src/__tests__/stripe-price-resolution.test.ts
+++ b/apps/api/src/__tests__/stripe-price-resolution.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  STRIPE_PRICE_IDS,
+  STRIPE_PRICE_IDS_TEST,
+  getStripePriceIdMap,
+  isStripeTestMode,
+} from "@quickconv/shared";
+import { resolveStripePriceId, isTestModeEnv, PLAN_CONFIGS, type PlanId } from "../services/stripe";
+import type { Env } from "../types/env";
+
+/**
+ * #343: staging（test-mode キー）では test Price ID を、production（live キー）では live Price ID を
+ * 解決しなければならない。test-mode に live Price ID を渡すと Stripe が 500 を返し E2E が落ちる。
+ */
+describe("Stripe price resolution (test/live mode switch) - #343", () => {
+  it("isStripeTestMode は sk_test を true、sk_live を false と判定する", () => {
+    expect(isStripeTestMode("sk_test_abc")).toBe(true);
+    expect(isStripeTestMode("sk_live_abc")).toBe(false);
+    expect(isStripeTestMode(undefined)).toBe(false);
+    expect(isStripeTestMode("")).toBe(false);
+  });
+
+  it("isTestModeEnv は env.STRIPE_SECRET_KEY の接頭辞で判定する", () => {
+    expect(isTestModeEnv({ STRIPE_SECRET_KEY: "sk_test_x" } as Env)).toBe(true);
+    expect(isTestModeEnv({ STRIPE_SECRET_KEY: "sk_live_x" } as Env)).toBe(false);
+  });
+
+  it("isTest=true は TEST マップ、false は LIVE マップを解決する", () => {
+    expect(resolveStripePriceId("plus_monthly", "jpy", true)).toBe(STRIPE_PRICE_IDS_TEST.plus_monthly.jpy);
+    expect(resolveStripePriceId("plus_monthly", "jpy", false)).toBe(STRIPE_PRICE_IDS.plus_monthly.jpy);
+  });
+
+  it("test と live の Price ID は別物である（取り違え防止の回帰）", () => {
+    for (const planId of Object.keys(STRIPE_PRICE_IDS) as PlanId[]) {
+      for (const currency of ["jpy", "usd"] as const) {
+        const live = resolveStripePriceId(planId, currency, false);
+        const test = resolveStripePriceId(planId, currency, true);
+        expect(test).not.toBe(live);
+        expect(test).toMatch(/^price_/);
+        expect(live).toMatch(/^price_/);
+      }
+    }
+  });
+
+  it("全プラン×全通貨で TEST マップに Price ID が存在する（staging で undefined にならない）", () => {
+    for (const planId of Object.keys(PLAN_CONFIGS) as PlanId[]) {
+      for (const currency of ["jpy", "usd"] as const) {
+        expect(getStripePriceIdMap(true)[planId]?.[currency]).toMatch(/^price_/);
+      }
+    }
+  });
+
+  it("通貨が無い場合は jpy にフォールバックする", () => {
+    // @ts-expect-error - 無効通貨でのフォールバック挙動を検証
+    expect(resolveStripePriceId("pro_monthly", "eur", true)).toBe(STRIPE_PRICE_IDS_TEST.pro_monthly.jpy);
+  });
+});

--- a/apps/api/src/routes/checkout.ts
+++ b/apps/api/src/routes/checkout.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../types/env";
-import { createStripeClient, PLAN_CONFIGS, isValidPlanId, resolveStripePriceId, type SupportedCurrency } from "../services/stripe";
+import { createStripeClient, PLAN_CONFIGS, isValidPlanId, resolveStripePriceId, isTestModeEnv, type SupportedCurrency } from "../services/stripe";
 
 const checkout = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -64,7 +64,7 @@ checkout.post("/", async (c) => {
 
   let stripePriceId: string;
   try {
-    stripePriceId = resolveStripePriceId(body.planId, currency);
+    stripePriceId = resolveStripePriceId(body.planId, currency, isTestModeEnv(c.env));
   } catch {
     return c.json({ error: "invalid_plan", message: "Invalid plan ID." }, 400);
   }

--- a/apps/api/src/services/stripe.ts
+++ b/apps/api/src/services/stripe.ts
@@ -1,6 +1,6 @@
 import Stripe from "stripe";
 import type { Env } from "../types/env";
-import { STRIPE_PRICE_IDS, type SupportedCurrency } from "@quickconv/shared";
+import { getStripePriceIdMap, isStripeTestMode, type SupportedCurrency } from "@quickconv/shared";
 
 export function createStripeClient(env: Env): Stripe {
   return new Stripe(env.STRIPE_SECRET_KEY, {
@@ -33,12 +33,22 @@ export function isValidPlanId(id: string): id is PlanId {
 
 /**
  * Resolve the Stripe Price ID for a given plan and currency.
+ * isTest=true のとき test-mode マップ（staging 用）を解決する。
  * Falls back to JPY if the currency is not found.
  */
-export function resolveStripePriceId(planId: PlanId, currency: SupportedCurrency = "jpy"): string {
-  const config = STRIPE_PRICE_IDS[planId];
+export function resolveStripePriceId(
+  planId: PlanId,
+  currency: SupportedCurrency = "jpy",
+  isTest = false,
+): string {
+  const config = getStripePriceIdMap(isTest)[planId];
   if (!config) throw new Error(`Unknown planId: ${planId}`);
   return config[currency] ?? config.jpy;
+}
+
+/** env.STRIPE_SECRET_KEY の接頭辞から test-mode かを判定する */
+export function isTestModeEnv(env: Env): boolean {
+  return isStripeTestMode(env.STRIPE_SECRET_KEY);
 }
 
 export { type SupportedCurrency };

--- a/packages/shared/src/constants/stripe.ts
+++ b/packages/shared/src/constants/stripe.ts
@@ -1,7 +1,7 @@
 /**
- * Stripe Price IDs (test mode / sandbox)
- * These IDs map to pre-created products in the Stripe dashboard.
- * Switch to live mode IDs via environment variable overrides in production.
+ * Stripe Price IDs.
+ * LIVE / TEST の2マップを保持し、STRIPE_SECRET_KEY の接頭辞 (sk_test / sk_live) で
+ * 自動切替する。staging は test-mode キーなので TEST マップ、production は LIVE マップを解決する (#343)。
  */
 
 export interface StripePriceConfig {
@@ -37,12 +37,57 @@ export const STRIPE_PRICE_IDS: Record<string, StripePriceConfig> = {
   },
 };
 
+/**
+ * Stripe Price IDs per plan and currency (TEST mode).
+ * 本番(LIVE)価格を test-mode にミラーした ID。staging（test-mode キー）で使用する (#343)。
+ */
+export const STRIPE_PRICE_IDS_TEST: Record<string, StripePriceConfig> = {
+  pass_7d: {
+    jpy: "price_1TealsBsqjfyEDMQDmN2YaZn",
+    usd: "price_1TealsBsqjfyEDMQjDGL3jat",
+  },
+  pass_30d: {
+    jpy: "price_1TealtBsqjfyEDMQi1lUMTbC",
+    usd: "price_1TealuBsqjfyEDMQeRUbjjKy",
+  },
+  plus_monthly: {
+    jpy: "price_1TealvBsqjfyEDMQIXfTx6k7",
+    usd: "price_1TealwBsqjfyEDMQ3CWajRR2",
+  },
+  plus_yearly: {
+    jpy: "price_1TealwBsqjfyEDMQPEoRrHSE",
+    usd: "price_1TealyBsqjfyEDMQzFZoCCzT",
+  },
+  pro_monthly: {
+    jpy: "price_1TealyBsqjfyEDMQXuhKQMQh",
+    usd: "price_1TealzBsqjfyEDMQ5ZsFrS4Z",
+  },
+  pro_yearly: {
+    jpy: "price_1Team0BsqjfyEDMQobV9JblV",
+    usd: "price_1Team1BsqjfyEDMQgL9IkTre",
+  },
+};
+
+/** Stripe シークレットキーの接頭辞から test-mode かを判定する */
+export function isStripeTestMode(secretKey: string | undefined | null): boolean {
+  return typeof secretKey === "string" && secretKey.startsWith("sk_test");
+}
+
+/** モードに応じた Price ID マップを返す（test→TESTマップ / live→LIVEマップ） */
+export function getStripePriceIdMap(isTest: boolean): Record<string, StripePriceConfig> {
+  return isTest ? STRIPE_PRICE_IDS_TEST : STRIPE_PRICE_IDS;
+}
+
 /** Supported currencies */
 export type SupportedCurrency = "jpy" | "usd";
 
-/** Resolve the correct Stripe Price ID for a plan and currency */
-export function getStripePriceId(planId: string, currency: SupportedCurrency): string | null {
-  const config = STRIPE_PRICE_IDS[planId];
+/** Resolve the correct Stripe Price ID for a plan and currency（モード切替対応） */
+export function getStripePriceId(
+  planId: string,
+  currency: SupportedCurrency,
+  isTest = false,
+): string | null {
+  const config = getStripePriceIdMap(isTest)[planId];
   if (!config) return null;
   return config[currency];
 }


### PR DESCRIPTION
## 目的
staging の Stripe E2E（Plus月額/Pro月額/7日パス/30日パス）が 10日以上失敗していた #343 を解消する。

## 根本原因（調査で確定）
- staging Worker は **test-mode** の `STRIPE_SECRET_KEY` 想定だが、`packages/shared/src/constants/stripe.ts` が **LIVE Price ID をハードコード**していた。
- さらに調査の結果、**Stripe アカウントの test-mode には Product/Price が1件も存在しなかった**（本PRに先立ち、本番LIVE価格をミラーした test 価格12種を新規作成済み）。
- test キー × live Price ID → `checkout.sessions.create` が例外 → `/api/checkout` が 500 → Stripe Checkout に遷移せず E2E 失敗。

## 変更点
- `STRIPE_PRICE_IDS_TEST`（test 価格12種、本番ミラー）を追加
- `STRIPE_SECRET_KEY` の接頭辞（`sk_test`/`sk_live`）で test/live マップを自動選択（新規 env 不要）
- `resolveStripePriceId(planId, currency, isTest)` / `isTestModeEnv(env)` を追加し、checkout が env から判定
- ユニットテスト6件追加（test/live で別IDを解決すること等）、既存 checkout テストの assertion を更新

## テスト方法
- [x] `pnpm --filter @quickconv/shared build` PASS
- [x] api 型チェック（`tsc --noEmit`）PASS
- [x] api ユニットテスト **130/130 PASS**（新規 stripe-price-resolution 6件含む）
- [ ] main マージ後、staging の `e2e-stg`（Stripe 4テスト）PASS を確認（#343 の AC）

## 関連
- Closes #343
- 依存: staging Worker の `STRIPE_SECRET_KEY` を test-mode キーに設定済み（ユーザーが wrangler secret put 実施）
- test Price ID は memory `project_stripe_price_ids.md` に記録

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Stripe決済のテストモード判定ロジックを改善し、本番環境とテスト環境での価格ID解決を正確に処理するように修正しました。

* **Tests**
  * Stripe決済機能に関する包括的なテストスイートを新規追加し、テスト・本番両モードでの動作検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->