### PR TITLE
fix: Stripe E2E の認証競合を修正し staging E2E を緑化 (Closes #343)

### DIFF
--- a/apps/web/e2e/stripe-e2e.spec.ts
+++ b/apps/web/e2e/stripe-e2e.spec.ts
@@ -93,7 +93,17 @@ test.describe("Stripe 決済フロー", () => {
       await route.fulfill({ response });
     });
 
+    // 認証確定を待ってからクリックする。useAuth が /api/auth/me を解決する前にクリックすると
+    // user=null のため purchase-button が checkout ではなく login()（/api/auth/google へ遷移）に分岐し、
+    // checkout.stripe.com へ遷移せず空URLになる（#343 E2E auth race）。固定sleepではなく応答到達で決定的に待つ。
+    const authMeResponse = page.waitForResponse(
+      (r) => r.url().includes("/api/auth/me"),
+      { timeout: 30000 },
+    );
     await page.goto(`${STAGING_URL}/ja/pricing`);
+    const authBody = await (await authMeResponse).json().catch(() => ({}));
+    expect(authBody.authenticated, "E2E前提: /api/auth/me が authenticated=true を返すこと").toBe(true);
+
     // Cookie同意バナーが表示されたら閉じる（React hydration 後に出現するため waitFor で待つ）
     try {
       const consent = page.getByRole("button", { name: "同意する" });


### PR DESCRIPTION
## 背景
#343 の価格モード不一致は PR #349 で修正済み（test/live 自動切替 + test価格12種作成）。しかし staging の `e2e-stg` は同じ症状（`toHaveURL(/checkout\.stripe\.com/)` が `Received: ""`）で失敗し続けた。

## 根本原因（trace + コードで確定）
- `apps/web/src/hooks/use-auth.ts`: `login()` は `window.location.href = /api/auth/google` へ遷移する。
- `purchase-button.tsx`: `if (!user) { login(); return; }` — **user 未解決時は checkout を呼ばず login() に分岐**。
- E2E は pricing 表示直後に即 `dispatchEvent("click")` するため、`useAuth` の `/api/auth/me` fetch 未解決で `user=null` → login() → `/api/auth/google` へ遷移 → checkout.stripe.com に行かず空URL。
- trace 解析: ページは `/ja/pricing` のまま、checkout.stripe.com への遷移なし。

## 決定的検証
- test価格 `price_1Tealv…`(plus_monthly) で `stripe checkout sessions create` → `url: https://checkout.stripe.com/...` (status open) を確認。**価格・キー側は健全**。残る赤は本競合のみ。

## 変更点
- `beforeEach` で `/api/auth/me` 応答到達を**決定的に待機**（固定sleep不使用）し、`authenticated=true` を検証してからテスト本体のクリックに進む。

## テスト方法
- [x] `playwright test --list` で spec パース確認
- [ ] main マージ後、`e2e-stg`（Stripe 4テスト）PASS を CI で確認（#343 の真のAC）

## 関連
- Closes #343
- Builds on #349（価格 test/live 切替）