### PR TITLE
fix: Stripe E2E intercept の content-encoding 二重復号を修正 (Closes #343)

### DIFF
--- a/apps/web/e2e/stripe-e2e.spec.ts
+++ b/apps/web/e2e/stripe-e2e.spec.ts
@@ -76,22 +76,26 @@ test.describe("Stripe 決済フロー", () => {
       },
     ]);
 
+    // Cookie を注入して再フェッチし、br/gzip の二重復号を避けて fulfill するヘルパー。
+    // fulfill({response}) のみだと、復号済み body に content-encoding: br ヘッダが残り
+    // ブラウザが二重復号に失敗して frontend の res.json() が SyntaxError になる
+    // → purchase-button が catch して pricing に留まり checkout.stripe.com へ遷移しない (#343 の真因)。
+    const fulfillWithCookie = async (route: import("@playwright/test").Route) => {
+      const response = await route.fetch({
+        headers: { ...route.request().headers(), Cookie: `qc_auth=${token}` },
+      });
+      const headers = { ...response.headers() };
+      delete headers["content-encoding"];
+      delete headers["content-length"];
+      await route.fulfill({ response, headers, body: await response.body() });
+    };
+
     // Intercept /api/auth/me to ensure authenticated state in frontend
     // (workaround for cross-domain cookie restrictions in CI headless browser)
-    await page.route(`**/api/auth/me`, async (route) => {
-      const response = await route.fetch({
-        headers: { ...route.request().headers(), Cookie: `qc_auth=${token}` },
-      });
-      await route.fulfill({ response });
-    });
+    await page.route(`**/api/auth/me`, fulfillWithCookie);
 
     // Intercept /api/checkout to inject cookie
-    await page.route(`**/api/checkout`, async (route) => {
-      const response = await route.fetch({
-        headers: { ...route.request().headers(), Cookie: `qc_auth=${token}` },
-      });
-      await route.fulfill({ response });
-    });
+    await page.route(`**/api/checkout`, fulfillWithCookie);
 
     // 認証確定を待ってからクリックする。useAuth が /api/auth/me を解決する前にクリックすると
     // user=null のため purchase-button が checkout ではなく login()（/api/auth/google へ遷移）に分岐し、


### PR DESCRIPTION
## 背景
#343 の staging E2E は、価格切替(#349)・認証待ち(#351)・staging D1スキーマ修正・STRIPE_SECRET_KEY 再設定の後も `toHaveURL(/checkout\.stripe\.com/)` で失敗（pricing 滞留）し続けた。

## 根本原因（trace で確定）
trace 解析で **/api/checkout は 200 + checkout.stripe.com URL を返している**ことを確認（backend は正常）。一方 trace に `SyntaxError` と `content-encoding: br` の痕跡。

`page.route(...).fulfill({ response })` は `route.fetch()` の**復号済み body** に `content-encoding: br` ヘッダを残したまま返すため、ブラウザが二重復号に失敗 → frontend `purchase-button.tsx` の `await res.json()` が SyntaxError → `catch` で `setError` → `window.location.href` に到達せず pricing に滞留。

## 変更点
- `/api/auth/me` と `/api/checkout` の intercept を共通ヘルパー化し、fulfill 時に `content-encoding`/`content-length` を除去して**復号済み body を明示**。

## 検証
- `playwright test --list` で spec パース確認
- curl で staging /api/checkout が全4プラン 200 + checkout.stripe.com を返すことを確認済み
- [ ] main マージ後 `e2e-stg` PASS（#343 の真のAC）

## 関連
- Closes #343
- 連なる修正: #349（価格 test/live 切替）/ #351（認証待ち）/ staging D1 `hourly_request_counts` スキーマ再作成 / staging `STRIPE_SECRET_KEY` 再設定