### PR TITLE
feat(api): API プラン有料アップグレード経路（Stripe → api_keys.plan 配線）

### DIFF
--- a/apps/api/src/__tests__/developer-checkout.test.ts
+++ b/apps/api/src/__tests__/developer-checkout.test.ts
@@ -30,11 +30,20 @@ function createApp(user: { email: string; stripeCustomerId: string | null; plan:
   return app;
 }
 
-function createEnv(secretKey: string): Env {
+function createMockDb(rateLimitCount = 0) {
+  // rate-limit SELECT returns the current count; everything else is inert.
+  const first = vi.fn().mockResolvedValue(rateLimitCount > 0 ? { count: rateLimitCount } : null);
+  const run = vi.fn().mockResolvedValue({ success: true });
+  const bind = vi.fn(() => ({ first, run }));
+  const prepare = vi.fn(() => ({ bind }));
+  return { prepare, bind, first, run };
+}
+
+function createEnv(secretKey: string, db = createMockDb()): Env {
   return {
     STRIPE_SECRET_KEY: secretKey,
     APP_URL: "https://api.quickconv.cc",
-    DB: {} as unknown as D1Database,
+    DB: db as unknown as D1Database,
   } as unknown as Env;
 }
 
@@ -89,6 +98,14 @@ describe("POST /api/developer/checkout (#357)", () => {
     expect(arg.metadata.userEmail).toBe("dev@example.com");
     // planId must also ride on the subscription metadata so subscription.* events resolve it
     expect(arg.subscription_data.metadata.planId).toBe("api_starter_monthly");
+  });
+
+  it("returns 429 when the hourly checkout rate limit is exceeded", async () => {
+    const app = createApp({ email: "dev@example.com", stripeCustomerId: null, plan: "free" });
+    const env = createEnv("sk_test_xxx", createMockDb(10)); // count already at limit
+    const res = await postCheckout(app, { planId: "api_starter_monthly" }, env);
+    expect(res.status).toBe(429);
+    expect(mockSessionCreate).not.toHaveBeenCalled();
   });
 
   it("reuses an existing Stripe customer id when present", async () => {

--- a/apps/api/src/__tests__/developer-checkout.test.ts
+++ b/apps/api/src/__tests__/developer-checkout.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock only the stripe service; keep @quickconv/shared real so getApiStripePriceId
+// exercises the actual LIVE-empty / TEST-populated maps (#357 approval gate).
+vi.mock("../services/stripe", () => ({
+  createStripeClient: vi.fn(),
+  isTestModeEnv: (env: { STRIPE_SECRET_KEY?: string }) =>
+    env.STRIPE_SECRET_KEY?.startsWith("sk_test") ?? false,
+}));
+
+import developer from "../routes/developer";
+import { createStripeClient } from "../services/stripe";
+import { Hono } from "hono";
+import type { Env, AppVariables } from "../types/env";
+
+type HonoEnv = { Bindings: Env; Variables: AppVariables };
+
+const mockSessionCreate = vi.fn().mockResolvedValue({ url: "https://checkout.stripe.com/c/pay/api_session_123" });
+
+function createApp(user: { email: string; stripeCustomerId: string | null; plan: string } | null = null) {
+  (createStripeClient as ReturnType<typeof vi.fn>).mockReturnValue({
+    checkout: { sessions: { create: mockSessionCreate } },
+  });
+  const app = new Hono<HonoEnv>();
+  app.use("*", async (ctx, next) => {
+    ctx.set("user", user ? { ...user, googleId: null } : null);
+    await next();
+  });
+  app.route("/developer", developer);
+  return app;
+}
+
+function createEnv(secretKey: string): Env {
+  return {
+    STRIPE_SECRET_KEY: secretKey,
+    APP_URL: "https://api.quickconv.cc",
+    DB: {} as unknown as D1Database,
+  } as unknown as Env;
+}
+
+async function postCheckout(app: ReturnType<typeof createApp>, body: Record<string, unknown>, env: Env) {
+  const req = new Request("http://localhost/developer/checkout", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+  return app.fetch(req, env);
+}
+
+describe("POST /api/developer/checkout (#357)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const app = createApp(null);
+    const res = await postCheckout(app, { planId: "api_starter_monthly" }, createEnv("sk_test_xxx"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for a non-API / invalid plan id", async () => {
+    const app = createApp({ email: "dev@example.com", stripeCustomerId: null, plan: "free" });
+    const res = await postCheckout(app, { planId: "pro_monthly" }, createEnv("sk_test_xxx"));
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_plan");
+  });
+
+  it("returns 503 in LIVE mode because LIVE prices are not yet approved (empty string)", async () => {
+    const app = createApp({ email: "dev@example.com", stripeCustomerId: null, plan: "free" });
+    // sk_live → isTest=false → getApiStripePriceId returns null (LIVE empty) → fail-fast 503
+    const res = await postCheckout(app, { planId: "api_starter_monthly" }, createEnv("sk_live_xxx"));
+    expect(res.status).toBe(503);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe("not_available");
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a Stripe Checkout session and returns the url in TEST mode", async () => {
+    const app = createApp({ email: "dev@example.com", stripeCustomerId: null, plan: "free" });
+    const res = await postCheckout(app, { planId: "api_starter_monthly", locale: "en" }, createEnv("sk_test_xxx"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { url: string };
+    expect(body.url).toContain("checkout.stripe.com");
+    expect(mockSessionCreate).toHaveBeenCalledTimes(1);
+    const arg = mockSessionCreate.mock.calls[0][0];
+    expect(arg.mode).toBe("subscription");
+    expect(arg.metadata.planId).toBe("api_starter_monthly");
+    expect(arg.metadata.userEmail).toBe("dev@example.com");
+    // planId must also ride on the subscription metadata so subscription.* events resolve it
+    expect(arg.subscription_data.metadata.planId).toBe("api_starter_monthly");
+  });
+
+  it("reuses an existing Stripe customer id when present", async () => {
+    const app = createApp({ email: "dev@example.com", stripeCustomerId: "cus_real123", plan: "free" });
+    const res = await postCheckout(app, { planId: "api_pro_monthly" }, createEnv("sk_test_xxx"));
+    expect(res.status).toBe(200);
+    const arg = mockSessionCreate.mock.calls[0][0];
+    expect(arg.customer).toBe("cus_real123");
+    expect(arg.customer_email).toBeUndefined();
+  });
+});

--- a/apps/api/src/__tests__/webhook.test.ts
+++ b/apps/api/src/__tests__/webhook.test.ts
@@ -449,5 +449,30 @@ describe("webhook /stripe", () => {
       expect(db.bind.mock.calls).toContainEqual(["pro", "dev@example.com"]);
       expect(preparedSql().some((s) => /UPDATE users SET plan/.test(s))).toBe(false);
     });
+
+    it("subscription.deleted keeps the tier of another active API subscription (C-1)", async () => {
+      // otherApi lookup returns a remaining active pro subscription
+      db.first.mockResolvedValueOnce({ plan_type: "api_pro_monthly" });
+      await postWebhook(app, db, "customer.subscription.deleted", {
+        id: "sub_api_starter",
+        customer: "cus_api_1",
+      }, {
+        planId: "api_starter_monthly",
+        userEmail: "dev@example.com",
+      });
+      // must NOT downgrade to free while a pro subscription remains
+      expect(db.bind.mock.calls).toContainEqual(["pro", "dev@example.com"]);
+      expect(db.bind.mock.calls).not.toContainEqual(["free", "dev@example.com"]);
+    });
+
+    it("invoice.payment_succeeded for an API subscription does not touch users.plan (S-2)", async () => {
+      // subscription lookup returns an API plan row
+      db.first.mockResolvedValueOnce({ plan_type: "api_starter_monthly", stripe_customer_id: "cus_api_1" });
+      const res = await postWebhook(app, db, "invoice.payment_succeeded", {
+        subscription: "sub_api_1",
+      });
+      expect(res.status).toBe(200);
+      expect(preparedSql().some((s) => /UPDATE users SET plan/.test(s))).toBe(false);
+    });
   });
 });

--- a/apps/api/src/__tests__/webhook.test.ts
+++ b/apps/api/src/__tests__/webhook.test.ts
@@ -371,4 +371,83 @@ describe("webhook /stripe", () => {
     // postWebhook uses no STRIPE_WEBHOOK_SECRET and localhost → should pass
     expect(res.status).toBe(200);
   });
+
+  // -------------------------------------------------------------------------
+  // #357: API plan billing axis → api_keys.plan (separate from users.plan)
+  // -------------------------------------------------------------------------
+  describe("API plan billing (#357)", () => {
+    function preparedSql(): string[] {
+      return (db.prepare.mock.calls as unknown[][]).map((c) => String(c[0]));
+    }
+
+    it("checkout.session.completed for an API plan updates api_keys.plan to starter", async () => {
+      const res = await postWebhook(app, db, "checkout.session.completed", {
+        payment_intent: "pi_api_1",
+        subscription: "sub_api_1",
+      }, {
+        planId: "api_starter_monthly",
+        userEmail: "dev@example.com",
+        stripeCustomerId: "cus_api_1",
+      });
+
+      expect(res.status).toBe(200);
+      expect(preparedSql().some((s) => /UPDATE api_keys SET plan/.test(s))).toBe(true);
+      expect(db.bind.mock.calls).toContainEqual(["starter", "dev@example.com"]);
+      // must NOT write the consumer purchases/users tables for an API plan
+      expect(preparedSql().some((s) => /INSERT INTO purchases/.test(s))).toBe(false);
+      expect(preparedSql().some((s) => /UPDATE users SET plan/.test(s))).toBe(false);
+    });
+
+    it("api_pro_monthly maps to the pro tier", async () => {
+      await postWebhook(app, db, "checkout.session.completed", {
+        payment_intent: "pi_api_2",
+        subscription: "sub_api_2",
+      }, {
+        planId: "api_pro_monthly",
+        userEmail: "dev@example.com",
+        stripeCustomerId: "cus_api_2",
+      });
+      expect(db.bind.mock.calls).toContainEqual(["pro", "dev@example.com"]);
+    });
+
+    it("customer.subscription.deleted for an API plan downgrades api_keys.plan to free", async () => {
+      const res = await postWebhook(app, db, "customer.subscription.deleted", {
+        id: "sub_api_1",
+        customer: "cus_api_1",
+      }, {
+        planId: "api_starter_monthly",
+        userEmail: "dev@example.com",
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.bind.mock.calls).toContainEqual(["free", "dev@example.com"]);
+      // API-plan deletion must not fall through to the consumer downgrade logic
+      expect(preparedSql().some((s) => /UPDATE users SET plan/.test(s))).toBe(false);
+    });
+
+    it("customer.subscription.updated unpaid for an API plan downgrades to free", async () => {
+      await postWebhook(app, db, "customer.subscription.updated", {
+        id: "sub_api_1",
+        customer: "cus_api_1",
+        status: "unpaid",
+      }, {
+        planId: "api_starter_monthly",
+        userEmail: "dev@example.com",
+      });
+      expect(db.bind.mock.calls).toContainEqual(["free", "dev@example.com"]);
+    });
+
+    it("customer.subscription.updated active for an API plan sets the new tier", async () => {
+      await postWebhook(app, db, "customer.subscription.updated", {
+        id: "sub_api_1",
+        customer: "cus_api_1",
+        status: "active",
+      }, {
+        planId: "api_pro_monthly",
+        userEmail: "dev@example.com",
+      });
+      expect(db.bind.mock.calls).toContainEqual(["pro", "dev@example.com"]);
+      expect(preparedSql().some((s) => /UPDATE users SET plan/.test(s))).toBe(false);
+    });
+  });
 });

--- a/apps/api/src/routes/developer.ts
+++ b/apps/api/src/routes/developer.ts
@@ -29,6 +29,32 @@ function resolveFrontendBase(env: Env): string {
   return appUrl.origin;
 }
 
+/** Rate limit: max 10 API-plan checkout sessions per user per hour（消費者 checkout と同等）。 */
+const DEV_CHECKOUT_RATE_LIMIT = 10;
+
+async function checkDevCheckoutRateLimit(db: D1Database, email: string): Promise<boolean> {
+  const hourKey = new Date().toISOString().slice(0, 13); // YYYY-MM-DDTHH
+  const key = `dev_checkout:${email}:${hourKey}`;
+
+  const row = await db
+    .prepare(`SELECT count FROM hourly_request_counts WHERE key = ?`)
+    .bind(key)
+    .first<{ count: number }>();
+
+  if ((row?.count ?? 0) >= DEV_CHECKOUT_RATE_LIMIT) return false;
+
+  await db
+    .prepare(
+      `INSERT INTO hourly_request_counts (key, count, updated_at)
+       VALUES (?1, 1, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET count = count + 1, updated_at = datetime('now')`
+    )
+    .bind(key)
+    .run();
+
+  return true;
+}
+
 // POST /api/developer/keys — Create a new API key
 developer.post("/keys", async (c) => {
   const user = requireAuth(c);
@@ -111,6 +137,11 @@ developer.post("/checkout", async (c) => {
   const planId = body?.planId;
   if (!planId || !(API_PLAN_IDS as readonly string[]).includes(planId)) {
     return c.json({ error: { code: "invalid_plan", message: "Invalid API plan ID." } }, 400);
+  }
+
+  const allowed = await checkDevCheckoutRateLimit(c.env.DB, user.email);
+  if (!allowed) {
+    return c.json({ error: { code: "rate_limit", message: "Too many checkout requests. Please try again later." } }, 429);
   }
 
   const currency: SupportedCurrency = body?.currency === "usd" ? "usd" : "jpy";

--- a/apps/api/src/routes/developer.ts
+++ b/apps/api/src/routes/developer.ts
@@ -5,6 +5,8 @@ import {
   listApiKeysByUser,
   revokeApiKey,
 } from "../repositories/api-key-repository";
+import { createStripeClient, isTestModeEnv } from "../services/stripe";
+import { API_PLAN_IDS, getApiStripePriceId, type SupportedCurrency } from "@quickconv/shared";
 
 const developer = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -15,6 +17,16 @@ function requireAuth(c: { get: (key: "user") => AppVariables["user"]; json: (bod
     return c.json({ error: { code: "unauthorized", message: "Login required" } }, 401);
   }
   return user;
+}
+
+/** Resolve the frontend origin from FRONTEND_URL, or by stripping the api. host prefix. */
+function resolveFrontendBase(env: Env): string {
+  if (env.FRONTEND_URL) return env.FRONTEND_URL;
+  const appUrl = new URL(env.APP_URL);
+  if (appUrl.hostname.startsWith("api.")) {
+    appUrl.hostname = appUrl.hostname.slice(4);
+  }
+  return appUrl.origin;
 }
 
 // POST /api/developer/keys — Create a new API key
@@ -87,6 +99,62 @@ developer.delete("/keys/:id", async (c) => {
   }
 
   return c.json({ message: "API key revoked" });
+});
+
+// POST /api/developer/checkout — Start a Stripe Checkout for an API plan upgrade.
+// 消費者プラン checkout (/api/checkout) とは別軸。webhook が api_keys.plan を更新する。
+developer.post("/checkout", async (c) => {
+  const user = requireAuth(c);
+  if (user instanceof Response) return user;
+
+  const body = await c.req.json<{ planId?: string; currency?: string; locale?: string }>().catch(() => null);
+  const planId = body?.planId;
+  if (!planId || !(API_PLAN_IDS as readonly string[]).includes(planId)) {
+    return c.json({ error: { code: "invalid_plan", message: "Invalid API plan ID." } }, 400);
+  }
+
+  const currency: SupportedCurrency = body?.currency === "usd" ? "usd" : "jpy";
+  const isTest = isTestModeEnv(c.env);
+  const priceId = getApiStripePriceId(planId, currency, isTest);
+  if (!priceId) {
+    // LIVE Price 未承認（空文字）= 本番課金導線が未開通。fail-fast で 503。
+    console.warn(`API plan checkout unavailable: planId=${planId} currency=${currency} isTest=${isTest} (LIVE price not approved)`);
+    return c.json(
+      { error: { code: "not_available", message: "API plan billing is not available yet." } },
+      503,
+    );
+  }
+
+  const stripe = createStripeClient(c.env);
+  const frontendBase = resolveFrontendBase(c.env);
+  const locale = body?.locale === "ja" ? "ja" : "en";
+  const frontendUrl = `${frontendBase.replace(/\/+$/, "")}/${locale}`;
+
+  // Reuse a real Stripe Customer when available (must start with "cus_").
+  const hasRealStripeId = user.stripeCustomerId?.startsWith("cus_");
+  const customerParams = hasRealStripeId
+    ? { customer: user.stripeCustomerId! }
+    : { customer_email: user.email };
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      payment_method_types: ["card"],
+      line_items: [{ price: priceId, quantity: 1 }],
+      // planId/userEmail を session と subscription 双方の metadata に載せ、
+      // checkout.session.completed と customer.subscription.* の両経路で webhook が解決できるようにする。
+      metadata: { planId, userEmail: user.email, stripeCustomerId: user.stripeCustomerId || "" },
+      subscription_data: { metadata: { planId, userEmail: user.email } },
+      ...customerParams,
+      success_url: `${frontendUrl}/developers?upgraded=1`,
+      cancel_url: `${frontendUrl}/developers?canceled=1`,
+    });
+    return c.json({ url: session.url });
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    console.error("API plan checkout error:", errMsg);
+    return c.json({ error: { code: "checkout_failed", message: "Failed to create checkout session." } }, 500);
+  }
 });
 
 export default developer;

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { Env, AppVariables } from "../types/env";
 import { createStripeClient } from "../services/stripe";
 import { upsertSubscription, updateSubscriptionStatus } from "../repositories/subscription-repository";
-import { higherPlan, type UserPlan } from "@quickconv/shared";
+import { higherPlan, isApiPlanId, apiPlanTierFromId, type UserPlan } from "@quickconv/shared";
 
 const webhook = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -11,6 +11,17 @@ function planTierFromId(planId: string): UserPlan {
   if (planId.startsWith("pro")) return "pro";
   if (planId.startsWith("plus")) return "plus";
   return "pass";
+}
+
+/**
+ * Set api_keys.plan for every active key owned by a developer.
+ * API プラン課金は user 単位だが quota は key 単位のため、非失効キー全てを更新する。
+ */
+async function setApiKeysPlan(db: D1Database, userEmail: string, tier: "free" | "starter" | "pro"): Promise<void> {
+  await db
+    .prepare("UPDATE api_keys SET plan = ? WHERE user_email = ? AND revoked_at IS NULL")
+    .bind(tier, userEmail)
+    .run();
 }
 
 /** Stripe unix timestamp → ISO 8601 string */
@@ -58,6 +69,26 @@ webhook.post("/stripe", async (c) => {
       const subscriptionId = typeof session.subscription === "string" ? session.subscription : null;
 
       if (!planId) break;
+
+      // API プラン軸: api_keys.plan を更新する（消費者プランの purchases/users とは別経路）。
+      if (isApiPlanId(planId)) {
+        const userEmail = meta.userEmail;
+        if (userEmail) {
+          await setApiKeysPlan(db, userEmail, apiPlanTierFromId(planId));
+        }
+        // ライフサイクル管理用に subscription を記録（deleted/unpaid で free に戻す）。
+        if (subscriptionId && stripeCustomerId) {
+          await upsertSubscription(db, {
+            stripeSubscriptionId: subscriptionId,
+            stripeCustomerId,
+            planType: planId,
+            status: "active",
+            currentPeriodEnd: null,
+            cancelAtPeriodEnd: false,
+          });
+        }
+        break;
+      }
 
       // Idempotent check
       const existing = await db.prepare("SELECT id FROM purchases WHERE stripe_payment_intent_id = ?").bind(paymentIntentId).first();
@@ -114,6 +145,15 @@ webhook.post("/stripe", async (c) => {
         cancelAtPeriodEnd: sub.cancel_at_period_end === true,
       });
 
+      // API プラン軸: active/trialing で api_keys.plan を即時更新（users は触らない）。
+      if (isApiPlanId(planId)) {
+        const userEmail = sub.metadata?.userEmail;
+        if (userEmail && (sub.status === "active" || sub.status === "trialing")) {
+          await setApiKeysPlan(db, userEmail, apiPlanTierFromId(planId));
+        }
+        break;
+      }
+
       // AC-6: Upgrade takes effect immediately
       if (sub.status === "active" || sub.status === "trialing") {
         const planName = planTierFromId(planId);
@@ -146,6 +186,22 @@ webhook.post("/stripe", async (c) => {
         cancelAtPeriodEnd,
       });
 
+      // API プラン軸: status に応じて api_keys.plan を更新（users は触らない）。
+      if (isApiPlanId(planId)) {
+        const userEmail = sub.metadata?.userEmail;
+        if (userEmail) {
+          if (status === "active" || status === "trialing") {
+            await setApiKeysPlan(db, userEmail, apiPlanTierFromId(planId));
+          } else if (status === "unpaid") {
+            // 全リトライ枯渇: free に降格
+            await setApiKeysPlan(db, userEmail, "free");
+            console.warn(`API subscription ${subId} unpaid — api_keys downgraded to free`);
+          }
+          // past_due: grace period — プランを維持
+        }
+        break;
+      }
+
       if (status === "active" || status === "trialing") {
         // AC-6: Upgrade is immediate
         const planName = planTierFromId(planId);
@@ -170,6 +226,15 @@ webhook.post("/stripe", async (c) => {
       // AC-3: Mark subscription as canceled
       const sub = event.data.object;
       await updateSubscriptionStatus(db, sub.id, "canceled");
+
+      // API プラン軸: 解約で api_keys.plan を free に戻す。
+      if (isApiPlanId(sub.metadata?.planId)) {
+        const userEmail = sub.metadata?.userEmail;
+        if (userEmail) {
+          await setApiKeysPlan(db, userEmail, "free");
+        }
+        break;
+      }
 
       const customerId = sub.customer as string;
       if (customerId) {

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -81,11 +81,14 @@ webhook.post("/stripe", async (c) => {
         if (userEmail) {
           await setApiKeysPlan(db, userEmail, apiPlanTierFromId(planId));
         }
-        // ライフサイクル管理用に subscription を記録（deleted/unpaid で free に戻す）。
-        if (subscriptionId && stripeCustomerId) {
+        // ライフサイクル管理用に subscription を記録（deleted/unpaid の tier 解決に使う）。
+        // customer は Stripe が確定する session.customer を使う（meta.stripeCustomerId は
+        // 新規ユーザーで空文字 or 内部 UUID のため、ここでは信頼しない）。
+        const realCustomerId = typeof session.customer === "string" ? session.customer : "";
+        if (subscriptionId && realCustomerId) {
           await upsertSubscription(db, {
             stripeSubscriptionId: subscriptionId,
-            stripeCustomerId,
+            stripeCustomerId: realCustomerId,
             planType: planId,
             status: "active",
             currentPeriodEnd: null,

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -16,6 +16,11 @@ function planTierFromId(planId: string): UserPlan {
 /**
  * Set api_keys.plan for every active key owned by a developer.
  * API プラン課金は user 単位だが quota は key 単位のため、非失効キー全てを更新する。
+ *
+ * 信頼境界: userEmail は自サーバが checkout 時に書き込んだ metadata 由来。
+ * これを信頼できるのは Stripe 署名検証 (constructEventAsync) が本番で必須化されているため。
+ * 署名未検証イベントで任意 email を渡されると課金バイパスになるので、署名検証ゲートが前提。
+ * （消費者プラン経路も同じく metadata.userEmail を信頼しており設計は一貫している）
  */
 async function setApiKeysPlan(db: D1Database, userEmail: string, tier: "free" | "starter" | "pro"): Promise<void> {
   await db
@@ -227,11 +232,23 @@ webhook.post("/stripe", async (c) => {
       const sub = event.data.object;
       await updateSubscriptionStatus(db, sub.id, "canceled");
 
-      // API プラン軸: 解約で api_keys.plan を free に戻す。
+      // API プラン軸: 解約。同一 customer に他の有効な API サブスクが残っていれば
+      // その tier を維持し、無ければ free に戻す（消費者経路の otherActive 検査と同等）。
       if (isApiPlanId(sub.metadata?.planId)) {
         const userEmail = sub.metadata?.userEmail;
         if (userEmail) {
-          await setApiKeysPlan(db, userEmail, "free");
+          const customerId = sub.customer as string;
+          let nextTier: "free" | "starter" | "pro" = "free";
+          if (customerId) {
+            const otherApi = await db.prepare(
+              `SELECT plan_type FROM subscriptions
+               WHERE stripe_customer_id = ? AND status IN ('active', 'trialing')
+                 AND stripe_subscription_id != ? AND plan_type LIKE 'api%'
+               LIMIT 1`
+            ).bind(customerId, sub.id).first();
+            if (otherApi) nextTier = apiPlanTierFromId(otherApi.plan_type as string);
+          }
+          await setApiKeysPlan(db, userEmail, nextTier);
         }
         break;
       }
@@ -286,10 +303,14 @@ webhook.post("/stripe", async (c) => {
         const sub = await db.prepare("SELECT plan_type, stripe_customer_id FROM subscriptions WHERE stripe_subscription_id = ?")
           .bind(subId).first();
         if (sub) {
-          const planName = planTierFromId(sub.plan_type as string);
           await updateSubscriptionStatus(db, subId, "active");
-          await db.prepare("UPDATE users SET plan = ?, updated_at = datetime('now') WHERE stripe_subscription_id = ?")
-            .bind(planName, subId).run();
+          // API プラン軸は users.plan を触らない。api_keys.plan の復帰は
+          // customer.subscription.updated(status=active) が担当する。
+          if (!isApiPlanId(sub.plan_type as string)) {
+            const planName = planTierFromId(sub.plan_type as string);
+            await db.prepare("UPDATE users SET plan = ?, updated_at = datetime('now') WHERE stripe_subscription_id = ?")
+              .bind(planName, subId).run();
+          }
         }
       }
       break;

--- a/apps/web/src/app/[locale]/developers/page.tsx
+++ b/apps/web/src/app/[locale]/developers/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Breadcrumb } from "@/components/breadcrumb";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { ApiPlanUpgrade } from "@/components/api-plan-upgrade";
 import { locales, type Locale } from "@/lib/i18n/config";
 import { buildPageMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
@@ -163,6 +164,9 @@ export default async function DevelopersPage({
           })}
         </div>
       </section>
+
+      {/* Upgrade CTA (API plan billing — #357) */}
+      <ApiPlanUpgrade />
 
       {/* Comparison */}
       <section className="py-12">

--- a/apps/web/src/app/[locale]/legal/commercial-transactions/page.tsx
+++ b/apps/web/src/app/[locale]/legal/commercial-transactions/page.tsx
@@ -1,0 +1,106 @@
+import { setRequestLocale } from "next-intl/server";
+import { Breadcrumb } from "@/components/breadcrumb";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { locales, type Locale } from "@/lib/i18n/config";
+import { buildPageMetadata } from "@/lib/metadata";
+import type { Metadata } from "next";
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return buildPageMetadata({
+    title: "特定商取引法に基づく表記 | QuickConv",
+    description:
+      "QuickConv の特定商取引法に基づく表記。販売事業者・販売価格・支払方法・役務の提供時期・返金/解約ポリシーを記載しています。",
+    locale: locale as Locale,
+    path: "/legal/commercial-transactions",
+  });
+}
+
+// 特定商取引法に基づく表記（日本の法令に基づく開示。日英共通で日本語表記を掲載する）。
+// NOTE: 「販売事業者」は個人事業主の氏名（実名）。デプロイ前に実名へ差し替えること。
+const OPERATOR_NAME = "宮下 寛之"; // TODO(#357): 運営責任者の実名に確定。仮置き。
+const SUPPORT_EMAIL = "quickconv.cc@gmail.com";
+
+const ROWS: { label: string; value: string }[] = [
+  { label: "販売事業者", value: OPERATOR_NAME },
+  { label: "運営統括責任者", value: OPERATOR_NAME },
+  {
+    label: "所在地",
+    value: "個人事業のため、ご請求をいただいた場合は遅滞なく開示いたします。",
+  },
+  {
+    label: "電話番号",
+    value: "個人事業のため、ご請求をいただいた場合は遅滞なく開示いたします。",
+  },
+  { label: "メールアドレス", value: SUPPORT_EMAIL },
+  { label: "販売URL", value: "https://quickconv.cc" },
+  {
+    label: "販売価格",
+    value:
+      "各料金ページおよびご購入手続き画面に表示する金額（消費税込）。例: API Starter ¥980/月、API Pro ¥4,980/月。料金ページ（/pricing, /developers）に最新の価格を表示します。",
+  },
+  {
+    label: "商品代金以外の必要料金",
+    value: "なし。インターネット接続料金・通信料金等はお客様のご負担となります。",
+  },
+  { label: "支払方法", value: "クレジットカード（Stripe による決済）。" },
+  {
+    label: "支払時期",
+    value:
+      "買い切り商品は購入手続き時に即時課金。サブスクリプションは初回購入時、および毎月（または毎年）の自動更新時に課金されます。",
+  },
+  {
+    label: "役務の提供時期",
+    value: "決済完了後、ただちにサービスをご利用いただけます。",
+  },
+  {
+    label: "返品・キャンセル・解約",
+    value:
+      "デジタルサービスの性質上、決済完了後の返金・返品は原則としてお受けできません。サブスクリプションはアカウントページからいつでも解約でき、解約後は次回更新日以降の課金は発生しません（既にお支払い済みの期間の日割り返金はありません）。",
+  },
+  {
+    label: "動作環境",
+    value: "最新版の主要ブラウザ（Google Chrome / Safari / Firefox / Microsoft Edge）。",
+  },
+];
+
+export default async function CommercialTransactionsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const title = "特定商取引法に基づく表記";
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12">
+      <BreadcrumbJsonLd locale={locale as Locale} items={[{ name: title }]} />
+      <Breadcrumb items={[{ label: title }]} />
+      <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+      {locale === "en" && (
+        <p className="mt-2 text-sm text-muted-foreground">
+          This is the disclosure required under Japan&rsquo;s Act on Specified Commercial
+          Transactions (特定商取引法). It is presented in Japanese as required by law.
+        </p>
+      )}
+
+      <dl className="mt-8 divide-y divide-border border-y border-border">
+        {ROWS.map((row) => (
+          <div key={row.label} className="grid grid-cols-1 gap-1 py-4 sm:grid-cols-3 sm:gap-4">
+            <dt className="text-sm font-semibold">{row.label}</dt>
+            <dd className="text-sm text-muted-foreground sm:col-span-2">{row.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/legal/commercial-transactions/page.tsx
+++ b/apps/web/src/app/[locale]/legal/commercial-transactions/page.tsx
@@ -25,11 +25,13 @@ export async function generateMetadata({
 }
 
 // 特定商取引法に基づく表記（日本の法令に基づく開示。日英共通で日本語表記を掲載する）。
-// NOTE: 「販売事業者」は個人事業主の氏名（実名）。デプロイ前に実名へ差し替えること。
-const OPERATOR_NAME = "宮下 寛之"; // TODO(#357): 運営責任者の実名に確定。仮置き。
+// 販売事業者は個人事業主の実名（開業届に基づく）。屋号は未登録のためサービス名を併記する。
+const OPERATOR_NAME = "宮下 博行"; // 開業届の氏名（ミヤシタ ヒロユキ）
+const SERVICE_NAME = "QuickConv";
 const SUPPORT_EMAIL = "quickconv.cc@gmail.com";
 
 const ROWS: { label: string; value: string }[] = [
+  { label: "サービス名", value: SERVICE_NAME },
   { label: "販売事業者", value: OPERATOR_NAME },
   { label: "運営統括責任者", value: OPERATOR_NAME },
   {

--- a/apps/web/src/components/api-plan-upgrade.tsx
+++ b/apps/web/src/components/api-plan-upgrade.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useAuth } from "@/hooks/use-auth";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8787";
+
+type ApiPlan = "free" | "starter" | "pro";
+
+/** Rank API plans so we can show the highest plan across a user's keys. */
+const PLAN_RANK: Record<ApiPlan, number> = { free: 0, starter: 1, pro: 2 };
+
+interface DeveloperKey {
+  plan?: string;
+}
+
+/**
+ * API プランのアップグレード導線（#357）。
+ * ログイン状態と現プランを表示し、Stripe Checkout を起動する。
+ */
+export function ApiPlanUpgrade() {
+  const { user, loading: authLoading, login } = useAuth();
+  const locale = useLocale();
+  const t = useTranslations("developers");
+
+  const [currentPlan, setCurrentPlan] = useState<ApiPlan>("free");
+  const [loadingPlan, setLoadingPlan] = useState(false);
+  const [submitting, setSubmitting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    setLoadingPlan(true);
+    fetch(`${API_URL}/api/developer/keys`, { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { keys?: DeveloperKey[] } | null) => {
+        if (!data?.keys?.length) return;
+        const highest = data.keys.reduce<ApiPlan>((acc, k) => {
+          const p = (k.plan as ApiPlan) ?? "free";
+          return PLAN_RANK[p] > PLAN_RANK[acc] ? p : acc;
+        }, "free");
+        setCurrentPlan(highest);
+      })
+      .catch(() => {
+        // Non-fatal: keep showing free tier
+      })
+      .finally(() => setLoadingPlan(false));
+  }, [user]);
+
+  const handleUpgrade = useCallback(
+    async (planId: "api_starter_monthly" | "api_pro_monthly") => {
+      if (!user) {
+        login();
+        return;
+      }
+      setSubmitting(planId);
+      setError(null);
+      try {
+        const res = await fetch(`${API_URL}/api/developer/checkout`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ planId, currency: "jpy", locale }),
+        });
+        const data = await res.json().catch(() => null);
+        if (res.status === 503) {
+          setError(t("upgradeComingSoon"));
+          return;
+        }
+        if (!res.ok || !data?.url) {
+          setError(t("upgradeError"));
+          return;
+        }
+        window.location.href = data.url;
+      } catch {
+        setError(t("upgradeError"));
+      } finally {
+        setSubmitting(null);
+      }
+    },
+    [user, login, locale, t],
+  );
+
+  const planLabel = currentPlan.charAt(0).toUpperCase() + currentPlan.slice(1);
+
+  return (
+    <section className="py-12">
+      <h2 className="text-2xl font-bold text-center mb-6">{t("upgradeTitle")}</h2>
+
+      {user && !authLoading && (
+        <p className="text-center text-sm text-muted-foreground mb-8">
+          {t("upgradeCurrentPlan")}:{" "}
+          <span className="font-semibold text-foreground">{loadingPlan ? "…" : planLabel}</span>
+        </p>
+      )}
+
+      {currentPlan === "pro" ? (
+        <p className="text-center text-sm text-muted-foreground">{t("upgradeManage")}</p>
+      ) : (
+        <div className="flex gap-4 justify-center flex-wrap">
+          {currentPlan !== "starter" && (
+            <button
+              onClick={() => handleUpgrade("api_starter_monthly")}
+              disabled={submitting !== null}
+              className="inline-flex items-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-semibold hover:bg-primary/90 transition-colors disabled:opacity-60"
+            >
+              {submitting === "api_starter_monthly" ? "…" : !user ? t("upgradeLogin") : t("upgradeStarter")}
+            </button>
+          )}
+          <button
+            onClick={() => handleUpgrade("api_pro_monthly")}
+            disabled={submitting !== null}
+            className="inline-flex items-center px-6 py-3 rounded-lg border border-border font-semibold hover:bg-accent transition-colors disabled:opacity-60"
+          >
+            {submitting === "api_pro_monthly" ? "…" : !user ? t("upgradeLogin") : t("upgradePro")}
+          </button>
+        </div>
+      )}
+
+      {error && <p className="mt-4 text-sm text-red-500 text-center">{error}</p>}
+    </section>
+  );
+}

--- a/apps/web/src/components/api-plan-upgrade.tsx
+++ b/apps/web/src/components/api-plan-upgrade.tsx
@@ -38,7 +38,8 @@ export function ApiPlanUpgrade() {
         if (!data?.keys?.length) return;
         const highest = data.keys.reduce<ApiPlan>((acc, k) => {
           const p = (k.plan as ApiPlan) ?? "free";
-          return PLAN_RANK[p] > PLAN_RANK[acc] ? p : acc;
+          // 未知のプラン値は rank 0（free 相当）として安全に比較する
+          return (PLAN_RANK[p] ?? 0) > (PLAN_RANK[acc] ?? 0) ? p : acc;
         }, "free");
         setCurrentPlan(highest);
       })
@@ -82,7 +83,9 @@ export function ApiPlanUpgrade() {
     [user, login, locale, t],
   );
 
-  const planLabel = currentPlan.charAt(0).toUpperCase() + currentPlan.slice(1);
+  // 現プラン名は developers namespace の pricing キーでローカライズ（pricingFree/Starter/Pro）
+  const planLabelKey = (`pricing${currentPlan.charAt(0).toUpperCase()}${currentPlan.slice(1)}`) as "pricingFree";
+  const planLabel = t(planLabelKey);
 
   return (
     <section className="py-12">

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -113,6 +113,12 @@ export function Footer() {
               {t("termsOfService")}
             </Link>
             <Link
+              href="/legal/commercial-transactions"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t("commercialTransactions")}
+            </Link>
+            <Link
               href="/contact"
               className="text-muted-foreground hover:text-foreground transition-colors"
             >

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -27,6 +27,7 @@
     "language": "Language",
     "privacy": "Files are automatically deleted after 24 hours",
     "privacyPolicy": "Privacy Policy",
+    "commercialTransactions": "Commercial Transactions Act (JP)",
     "termsOfService": "Terms of Service",
     "home": "Home",
     "imageConversion": "Image Conversion",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -969,6 +969,14 @@
     "compareFormats": "Formats",
     "compareFocus": "Focus",
     "ctaTitle": "Start Converting in Minutes",
-    "ctaDesc": "Get your free API key and make your first conversion in under 5 minutes."
+    "ctaDesc": "Get your free API key and make your first conversion in under 5 minutes.",
+    "upgradeTitle": "Upgrade Your API Plan",
+    "upgradeCurrentPlan": "Your current API plan",
+    "upgradeStarter": "Upgrade to Starter",
+    "upgradePro": "Upgrade to Pro",
+    "upgradeLogin": "Log in to upgrade",
+    "upgradeComingSoon": "Paid API plans are launching soon.",
+    "upgradeError": "Could not start checkout. Please try again.",
+    "upgradeManage": "You're on a paid plan. Manage billing from your account."
   }
 }

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -962,6 +962,14 @@
     "compareFormats": "フォーマット数",
     "compareFocus": "特長",
     "ctaTitle": "数分で変換開始",
-    "ctaDesc": "無料APIキーを取得して、5分以内に最初の変換を実行しましょう。"
+    "ctaDesc": "無料APIキーを取得して、5分以内に最初の変換を実行しましょう。",
+    "upgradeTitle": "APIプランをアップグレード",
+    "upgradeCurrentPlan": "現在のAPIプラン",
+    "upgradeStarter": "Starterにアップグレード",
+    "upgradePro": "Proにアップグレード",
+    "upgradeLogin": "ログインしてアップグレード",
+    "upgradeComingSoon": "有料APIプランは近日公開予定です。",
+    "upgradeError": "チェックアウトを開始できませんでした。もう一度お試しください。",
+    "upgradeManage": "有料プランをご利用中です。請求の管理はアカウントから行えます。"
   }
 }

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -27,6 +27,7 @@
     "language": "言語",
     "privacy": "ファイルは24時間後に自動削除されます",
     "privacyPolicy": "プライバシーポリシー",
+    "commercialTransactions": "特定商取引法に基づく表記",
     "termsOfService": "利用規約",
     "home": "ホーム",
     "imageConversion": "画像変換",

--- a/packages/shared/src/__tests__/api-stripe.test.ts
+++ b/packages/shared/src/__tests__/api-stripe.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  API_PLAN_IDS,
+  isApiPlanId,
+  apiPlanTierFromId,
+  getApiStripePriceId,
+} from "../constants/stripe";
+
+describe("API plan stripe helpers (#357)", () => {
+  describe("isApiPlanId", () => {
+    it("returns true for api_* plan ids", () => {
+      expect(isApiPlanId("api_starter_monthly")).toBe(true);
+      expect(isApiPlanId("api_pro_monthly")).toBe(true);
+    });
+    it("returns false for consumer plan ids and junk", () => {
+      expect(isApiPlanId("pro_monthly")).toBe(false);
+      expect(isApiPlanId("plus_monthly")).toBe(false);
+      expect(isApiPlanId(undefined)).toBe(false);
+      expect(isApiPlanId(null)).toBe(false);
+      expect(isApiPlanId("")).toBe(false);
+    });
+  });
+
+  describe("apiPlanTierFromId", () => {
+    it("maps api plan ids to api_keys.plan tier", () => {
+      expect(apiPlanTierFromId("api_starter_monthly")).toBe("starter");
+      expect(apiPlanTierFromId("api_pro_monthly")).toBe("pro");
+    });
+    it("falls back to free for unknown ids", () => {
+      expect(apiPlanTierFromId("api_unknown")).toBe("free");
+      expect(apiPlanTierFromId("pro_monthly")).toBe("free");
+    });
+  });
+
+  describe("getApiStripePriceId", () => {
+    it("resolves a non-empty TEST price id for both currencies", () => {
+      expect(getApiStripePriceId("api_starter_monthly", "jpy", true)).toMatch(/^price_/);
+      expect(getApiStripePriceId("api_starter_monthly", "usd", true)).toMatch(/^price_/);
+      expect(getApiStripePriceId("api_pro_monthly", "jpy", true)).toMatch(/^price_/);
+    });
+
+    it("returns null for LIVE because the products are not yet approved (empty string)", () => {
+      // LIVE 未承認ゲート: 空文字 → null → checkout 側で 503
+      expect(getApiStripePriceId("api_starter_monthly", "jpy", false)).toBeNull();
+      expect(getApiStripePriceId("api_pro_monthly", "usd", false)).toBeNull();
+    });
+
+    it("returns null for unknown plan ids", () => {
+      expect(getApiStripePriceId("api_does_not_exist", "jpy", true)).toBeNull();
+    });
+  });
+
+  it("API_PLAN_IDS lists exactly the billable plans", () => {
+    expect([...API_PLAN_IDS]).toEqual(["api_starter_monthly", "api_pro_monthly"]);
+  });
+});

--- a/packages/shared/src/constants/stripe.ts
+++ b/packages/shared/src/constants/stripe.ts
@@ -91,3 +91,69 @@ export function getStripePriceId(
   if (!config) return null;
   return config[currency];
 }
+
+// ---------------------------------------------------------------------------
+// 開発者向け API プラン（消費者プランとは別軸の課金。api_keys.plan を更新する）
+// #357 / Epic #280。tier は api_keys.plan の CHECK 制約（free/starter/pro）に対応。
+// ---------------------------------------------------------------------------
+
+/** 課金可能な API プランID一覧 */
+export const API_PLAN_IDS = ["api_starter_monthly", "api_pro_monthly"] as const;
+export type ApiPlanId = (typeof API_PLAN_IDS)[number];
+
+/**
+ * API プランの Stripe Price ID (LIVE mode)。
+ * LIVE Product/Price は本番課金操作のため未承認 = 空文字。
+ * checkout は空文字を検出したら 503 を返す（fail-fast、本番課金導線の承認ゲート）。
+ */
+export const API_STRIPE_PRICE_IDS: Record<string, StripePriceConfig> = {
+  api_starter_monthly: { jpy: "", usd: "" },
+  api_pro_monthly: { jpy: "", usd: "" },
+};
+
+/**
+ * API プランの Stripe Price ID (TEST mode)。staging で使用 (#357)。
+ * test product: Starter=prod_UdwLvbf34dbr4Y(¥980/mo) / Pro=prod_UdwPu6GANV2C5A(¥4,980/mo)。
+ */
+export const API_STRIPE_PRICE_IDS_TEST: Record<string, StripePriceConfig> = {
+  api_starter_monthly: {
+    jpy: "price_1TeeURBsqjfyEDMQMIRXFVvl",
+    usd: "price_1TeeWsBsqjfyEDMQI6Dsom5S",
+  },
+  api_pro_monthly: {
+    jpy: "price_1TeeWvBsqjfyEDMQW4ykKV7b",
+    usd: "price_1TeeWwBsqjfyEDMQJ1pqcD1s",
+  },
+};
+
+/** planId が API プラン軸かを判定する（消費者プランと区別する） */
+export function isApiPlanId(planId: string | undefined | null): boolean {
+  return typeof planId === "string" && planId.startsWith("api_");
+}
+
+/** API プランID → api_keys.plan tier（free/starter/pro）。不明は free。 */
+export function apiPlanTierFromId(planId: string): "free" | "starter" | "pro" {
+  if (planId.startsWith("api_pro")) return "pro";
+  if (planId.startsWith("api_starter")) return "starter";
+  return "free";
+}
+
+/** モードに応じた API プランの Price ID マップを返す */
+export function getApiStripePriceIdMap(isTest: boolean): Record<string, StripePriceConfig> {
+  return isTest ? API_STRIPE_PRICE_IDS_TEST : API_STRIPE_PRICE_IDS;
+}
+
+/**
+ * API プランの Price ID を解決する。
+ * LIVE 未承認（空文字）または未知プランは null（呼び出し側で 503 fail-fast）。
+ */
+export function getApiStripePriceId(
+  planId: string,
+  currency: SupportedCurrency,
+  isTest = false,
+): string | null {
+  const config = getApiStripePriceIdMap(isTest)[planId];
+  if (!config) return null;
+  const id = config[currency] ?? config.jpy;
+  return id && id.length > 0 ? id : null;
+}


### PR DESCRIPTION
Closes #357

## 目的
Epic #280（API課金ピボット）の核心「課金可能状態」を達成。free → Starter/Pro の課金アップグレード経路を配線する。基盤（Key発行/認証/quota/変換API/docs/LP）は #281-#285 で完成済みだったが、開発者が課金してアップグレードする導線が無く `/developers` LP は購入不可の価格を宣伝している状態だった。

## 主な変更
- **packages/shared/constants/stripe.ts**: API プラン Stripe Price 定数を追加。`API_STRIPE_PRICE_IDS`（LIVE = 空文字 = 承認ゲート）/ `API_STRIPE_PRICE_IDS_TEST`（test 充填済み）+ `isApiPlanId` / `apiPlanTierFromId` / `getApiStripePriceId` ヘルパー。#349 の test/live 切替パターンを踏襲（DRY）。
- **apps/api/routes/developer.ts**: `POST /api/developer/checkout` を追加。認証必須・subscription モード・LIVE 未承認（空文字）検出時は 503 fail-fast。planId/userEmail を session と subscription 双方の metadata に載せ webhook が両経路で解決可能に。
- **apps/api/routes/webhook.ts**: `api_` プレフィックスのプラン検出で `api_keys.plan` を starter/pro/free に更新（消費者 `users.plan` とは別軸）。checkout.session.completed / customer.subscription.created/updated/deleted の 4 経路に分岐を追加。unpaid/deleted で free 降格。
- **apps/web developers**: アップグレード導線コンポーネント（現プラン表示 + checkout 起動、ja/en i18n）。
- **テスト（TDD, 計 31 ケース）**: shared price 解決 8 / developer-checkout 401・400・503・url・customer 再利用 5 / webhook api_keys 配線 5 + 既存リグレッション。

## 検証
- shared 54/54 PASS、api 140/140 PASS、web build（静的エクスポート両 locale）+ lint(tsc) 全 exit 0。
- developers.html に upgrade UI が両 locale で描画されることを確認。

## 統合ジャーニーAC
- AC-2/AC-3 のロジック（api_keys.plan 更新 → quota=5000 → X-RateLimit-Limit ヘッダ）は単体で決定的に担保。AC-1 の実 Stripe Checkout 遷移は staging E2E（e2e-stg）で最終検証。

## ⚠️ マージ前 承認ゲート（本番課金）
LIVE Stripe Product/Price は本番課金操作のため **未作成（空文字）**。checkout は LIVE で 503 を返す fail-fast。**本番課金導線の開通には LIVE products 作成 + `API_STRIPE_PRICE_IDS` 充填の承認が必須**。test mode のみで実装完結しており、本番課金操作は一切行っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 開発者向けAPIプラン（Starter/Pro）へのアップグレード導線を追加し、Stripe Checkout経由で支払い可能に
  * 現在のAPIプラン表示とアップグレードボタンを含むUIコンポーネントを追加
  * 利用規約関連の「特定商取引法」ページを追加し、フッターへリンクを掲載

* **Tests**
  * APIプラン課金まわりとStripe連携の包括的なテストを追加

* **Localization**
  * アップグレード関連の英日メッセージを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->