### PR TITLE
feat(api): API プラン LIVE Price ID 充填で本番課金導線を開通 (Refs #357)

### DIFF
--- a/apps/api/src/__tests__/developer-checkout.test.ts
+++ b/apps/api/src/__tests__/developer-checkout.test.ts
@@ -75,14 +75,18 @@ describe("POST /api/developer/checkout (#357)", () => {
     expect(body.error.code).toBe("invalid_plan");
   });
 
-  it("returns 503 in LIVE mode because LIVE prices are not yet approved (empty string)", async () => {
+  it("creates a Stripe Checkout session in LIVE mode (#357: Stripe 審査通過後に LIVE Price 充填)", async () => {
     const app = createApp({ email: "dev@example.com", stripeCustomerId: null, plan: "free" });
-    // sk_live → isTest=false → getApiStripePriceId returns null (LIVE empty) → fail-fast 503
+    // sk_live → isTest=false → getApiStripePriceId returns the LIVE price id → subscription checkout
     const res = await postCheckout(app, { planId: "api_starter_monthly" }, createEnv("sk_live_xxx"));
-    expect(res.status).toBe(503);
-    const body = await res.json() as { error: { code: string } };
-    expect(body.error.code).toBe("not_available");
-    expect(mockSessionCreate).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    const body = await res.json() as { url: string };
+    expect(body.url).toContain("checkout.stripe.com");
+    expect(mockSessionCreate).toHaveBeenCalledTimes(1);
+    const arg = mockSessionCreate.mock.calls[0][0];
+    expect(arg.mode).toBe("subscription");
+    // LIVE price id must be used (starts with "price_")
+    expect(arg.line_items[0].price).toMatch(/^price_/);
   });
 
   it("creates a Stripe Checkout session and returns the url in TEST mode", async () => {

--- a/packages/shared/src/__tests__/api-stripe.test.ts
+++ b/packages/shared/src/__tests__/api-stripe.test.ts
@@ -39,10 +39,12 @@ describe("API plan stripe helpers (#357)", () => {
       expect(getApiStripePriceId("api_pro_monthly", "jpy", true)).toMatch(/^price_/);
     });
 
-    it("returns null for LIVE because the products are not yet approved (empty string)", () => {
-      // LIVE 未承認ゲート: 空文字 → null → checkout 側で 503
-      expect(getApiStripePriceId("api_starter_monthly", "jpy", false)).toBeNull();
-      expect(getApiStripePriceId("api_pro_monthly", "usd", false)).toBeNull();
+    it("resolves a non-empty LIVE price id for both plans (#357: Stripe 審査通過後に LIVE Price 充填)", () => {
+      // LIVE 承認ゲート開通: charges_enabled=true 確認後に LIVE Price ID を充填済み
+      expect(getApiStripePriceId("api_starter_monthly", "jpy", false)).toMatch(/^price_/);
+      expect(getApiStripePriceId("api_starter_monthly", "usd", false)).toMatch(/^price_/);
+      expect(getApiStripePriceId("api_pro_monthly", "jpy", false)).toMatch(/^price_/);
+      expect(getApiStripePriceId("api_pro_monthly", "usd", false)).toMatch(/^price_/);
     });
 
     it("returns null for unknown plan ids", () => {

--- a/packages/shared/src/constants/stripe.ts
+++ b/packages/shared/src/constants/stripe.ts
@@ -103,12 +103,18 @@ export type ApiPlanId = (typeof API_PLAN_IDS)[number];
 
 /**
  * API プランの Stripe Price ID (LIVE mode)。
- * LIVE Product/Price は本番課金操作のため未承認 = 空文字。
- * checkout は空文字を検出したら 503 を返す（fail-fast、本番課金導線の承認ゲート）。
+ * Stripe アカウント審査通過 (charges_enabled=true, 2026-06-06) 後に LIVE Product/Price を作成し充填した (#357)。
+ * live product: Starter=prod_UecXrtOKpMftsl(¥980/mo) / Pro=prod_UecXjv9aRjO3qe(¥4,980/mo)。
  */
 export const API_STRIPE_PRICE_IDS: Record<string, StripePriceConfig> = {
-  api_starter_monthly: { jpy: "", usd: "" },
-  api_pro_monthly: { jpy: "", usd: "" },
+  api_starter_monthly: {
+    jpy: "price_1TfJIgBsqjfyEDMQwtwkR2oQ",
+    usd: "price_1TfJIhBsqjfyEDMQkxGoQIpt",
+  },
+  api_pro_monthly: {
+    jpy: "price_1TfJIiBsqjfyEDMQqfQD0sqn",
+    usd: "price_1TfJIjBsqjfyEDMQs08xz3pW",
+  },
 };
 
 /**


### PR DESCRIPTION
## 目的
Stripe アカウント審査通過 (`charges_enabled=true`, 2026-06-06 決定的確認済) を受け、API プラン (Starter/Pro) の **LIVE Price ID** を作成・充填し、本番 API プラン課金 checkout 導線を開通する。Epic #280 / Refs #357。

## 背景
これまで `API_STRIPE_PRICE_IDS`(LIVE) は空文字で、`getApiStripePriceId` が null → checkout が 503 (`not_available`) を返す承認ゲートだった。審査通過後に LIVE Product/Price を作成して充填する。

## 変更点
- `packages/shared/src/constants/stripe.ts`: `API_STRIPE_PRICE_IDS`(LIVE) に 4 つの LIVE Price ID を充填
  - Starter: JPY ¥980 (`price_1TfJIgBsqjfyEDMQwtwkR2oQ`) / USD \$6.99 (`price_1TfJIhBsqjfyEDMQkxGoQIpt`) — product `prod_UecXrtOKpMftsl`
  - Pro: JPY ¥4,980 (`price_1TfJIiBsqjfyEDMQqfQD0sqn`) / USD \$34.99 (`price_1TfJIjBsqjfyEDMQs08xz3pW`) — product `prod_UecXjv9aRjO3qe`
- `packages/shared/.../api-stripe.test.ts`: LIVE→null 前提テストを LIVE→price_ 解決に更新
- `apps/api/.../developer-checkout.test.ts`: LIVE→503 前提テストを LIVE→200 (subscription checkout url) に更新

## 影響範囲 / 非変更
- 消費者プラン軸 (`checkout.ts`) は無変更（デグレなし）
- webhook は metadata 経由で `api_keys.plan` を更新するため Price ID 非依存

## テスト
- `pnpm --filter @quickconv/shared test` → 54 passed
- `cd apps/api && pnpm test` → 143 passed
- LIVE Price は Stripe API で active / month / 金額一致を決定的に検証済

## 本番デプロイ後の確認 (マージ後)
1. Web/API CI 自動デプロイ完了
2. `/developers` から LIVE 課金テスト（ユーザー実施）
3. webhook で `api_keys.plan` が starter/pro に更新されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * API チェックアウト機能が本番環境で正常に動作するよう改善しました。

* **New Features**
  * API プランの本番環境での価格設定が有効になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->