### PR TITLE
fix(web): 開発者ページ等の内部CTAリンクをロケール対応にして404を解消 (Refs #357)

### DIFF
--- a/apps/web/src/app/[locale]/developers/page.tsx
+++ b/apps/web/src/app/[locale]/developers/page.tsx
@@ -3,6 +3,7 @@ import { Breadcrumb } from "@/components/breadcrumb";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
 import { ApiPlanUpgrade } from "@/components/api-plan-upgrade";
 import { locales, type Locale } from "@/lib/i18n/config";
+import { Link } from "@/lib/i18n/navigation";
 import { buildPageMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
 
@@ -85,12 +86,12 @@ export default async function DevelopersPage({
           {t("subtitle")}
         </p>
         <div className="mt-8 flex gap-4 justify-center flex-wrap">
-          <a
+          <Link
             href="/account"
             className="inline-flex items-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-semibold hover:bg-primary/90 transition-colors"
           >
             {t("getApiKey")}
-          </a>
+          </Link>
           <a
             href="#docs"
             className="inline-flex items-center px-6 py-3 rounded-lg border border-border font-semibold hover:bg-accent transition-colors"
@@ -204,12 +205,12 @@ export default async function DevelopersPage({
         <p className="mt-4 text-muted-foreground max-w-xl mx-auto">
           {t("ctaDesc")}
         </p>
-        <a
+        <Link
           href="/account"
           className="inline-flex items-center mt-8 px-8 py-4 rounded-lg bg-primary text-primary-foreground font-semibold text-lg hover:bg-primary/90 transition-colors"
         >
           {t("getApiKey")}
-        </a>
+        </Link>
       </section>
     </div>
   );

--- a/apps/web/src/components/conversion-card.tsx
+++ b/apps/web/src/components/conversion-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
+import { Link } from "@/lib/i18n/navigation";
 import {
   Download,
   RefreshCw,
@@ -259,9 +260,9 @@ export function ConversionCard({ presetFormat }: ConversionCardProps = {}) {
                 <p className="text-xs text-center text-yellow-700 dark:text-yellow-300">
                   {t("softUpsell", { remaining: remainingConversions })}
                   {" "}
-                  <a href="/pricing" className="underline font-medium hover:text-yellow-900 dark:hover:text-yellow-100">
+                  <Link href="/pricing" className="underline font-medium hover:text-yellow-900 dark:hover:text-yellow-100">
                     {t("softUpsellLink")}
-                  </a>
+                  </Link>
                 </p>
               )}
             </div>


### PR DESCRIPTION
## 概要
`#357`（API プラン有料アップグレード経路）で開通したはずの導線のうち、**「Get Your Free API Key」CTA が 404** になっていた問題を修正する。あわせて同型の壊れリンク（変換カードの上限間近アップセル）も修正。

## 再現手順（証拠2種以上）
1. 実行（本番）:

   ```bash
   curl -s -o /dev/null -w '%{http_code}' -L https://quickconv.cc/account      # → 404
   curl -s -o /dev/null -w '%{http_code}' -L https://quickconv.cc/en/account   # → 200
   curl -s -o /dev/null -w '%{http_code}' -L https://quickconv.cc/pricing      # → 404
   curl -s -o /dev/null -w '%{http_code}' -L https://quickconv.cc/en/pricing   # → 200
   ```
2. 観察: `/en/developers` の「Get Your Free API Key」ボタンの href が `/account`（ロケール接頭辞なし）。クリックで 404。

## 根本原因
- このサイトは `output: "export"` の**静的エクスポート**（Cloudflare Pages）。静的エクスポートでは **next-intl middleware の locale redirect が実行されない**ため、`/account`・`/pricing` のような非ロケール接頭辞パスはリダイレクトされず 404 になる。
- 該当 CTA が raw `<a href="/account">` / `<a href="/pricing">` で、ロケール非対応だった。

## 修正
- 既設の locale-aware ナビゲーション（`@/lib/i18n/navigation` の `Link`）に統一。レンダ時に現在ロケールへ自動接頭辞（`/en/account`・`/ja/account` 等）。
  - `apps/web/src/app/[locale]/developers/page.tsx`: 「Get Your Free API Key」CTA ×2
  - `apps/web/src/components/conversion-card.tsx`: 上限間近アップセルの `/pricing`
- ページ内アンカー `#docs` は対象外（同一ページ内遷移）。

## 検証
- `tsc --noEmit`: PASS
- `next build`（静的エクスポート）: 成功。生成 HTML を確認:
  - `out/en/developers.html` → `href="/en/account"` / `out/ja/developers.html` → `href="/ja/account"`
  - bare `href="/account"` / `href="/pricing"` の残存: **0**
- マージ・デプロイ後に本番 `https://quickconv.cc/en/developers` の CTA → `/en/account`（200）を最終確認する。

## 統合ジャーニーAC
1. 操作: `/en/developers` で「Get Your Free API Key」押下 → 期待: `/en/account`（200, ログイン/キー発行画面） / 検証: デプロイ後 curl で 200
2. 操作: 変換で残量僅少時のアップセルリンク押下 → 期待: `/en/pricing`（200） / 検証: デプロイ後 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 内部ナビゲーション処理の改善により、アプリケーション全体の多言語対応処理がより一貫性と堅牢性を持つようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->