### PR TITLE
feat(playbook): devcycle/article goal playbook ＋ フェーズラベル（M4・#376）

### DIFF
--- a/.claude/commands/article.md
+++ b/.claude/commands/article.md
@@ -58,9 +58,14 @@ gh label create "done"           --color "5319E7" --description "完了（corp a
    `npm install` 禁止＝RW-052）。記事はこの時点で **未公開**（`published: false`）。
 4. **フェーズラベル付与 + 報告 + 停止**:
    ```bash
-   gh issue edit <N> --add-label "draft-returned"
-   gh issue comment <N> --body "## 下書き返却 - <timestamp>\n\n- 記事: docs/articles/<NNN>-<slug>.md（published:false）\n\n会長の承認をお待ちします（承認後に公開＋クロスポストへ進みます）。"
+   gh issue edit "$ARGUMENTS" --add-label "draft-returned"
+   gh issue comment "$ARGUMENTS" --body "## 下書き返却 - $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+   - 記事: docs/articles/{NNN}-{slug}.md（published:false）
+
+   会長の承認をお待ちします（承認後に公開＋クロスポストへ進みます）。"
    ```
+   （`{NNN}-{slug}` は作成した記事ファイル名に置換する）
    会長へ下書き（記事パス・要旨）を報告し、**ここで停止して会長の承認発言を待つ**。
 
 ---
@@ -73,8 +78,8 @@ gh label create "done"           --color "5319E7" --description "完了（corp a
    `tools/publish-{devto,hashnode}-<NNN>.mjs` を用意し実行する（必要 env: `DEVTO_API_KEY` /
    `HASHNODE_TOKEN` / `HASHNODE_PUBLICATION_ID`）。
    ```bash
-   npx dotenv -e .env -- node tools/publish-devto-<NNN>.mjs
-   npx dotenv -e .env -- node tools/publish-hashnode-<NNN>.mjs
+   npx dotenv -e .env -- node tools/publish-devto-{NNN}.mjs
+   npx dotenv -e .env -- node tools/publish-hashnode-{NNN}.mjs
    ```
 2. **note / Qiita / SNS（`tools/team_salary` submodule を流用）**: submodule 側の投稿モジュールで
    note / Qiita / X / Threads / IG へクロスポストする（`docs/articles/README.md` の流用方針に従う）。
@@ -82,7 +87,7 @@ gh label create "done"           --color "5319E7" --description "完了（corp a
    note,qiita,...}` に公開 URL を反映してコミットする。
 4. **フェーズラベル付与 + 報告 + 停止**:
    ```bash
-   gh issue edit <N> --remove-label "draft-returned" --add-label "published"
+   gh issue edit "$ARGUMENTS" --remove-label "draft-returned" --add-label "published"
    ```
    会長へ各プラットフォームの公開 URL を報告し、**会長の close を待つ**。
    - いずれかの公開が失敗したら、そのプラットフォームを切り分けて再試行（自己修復ポリシー）。主要公開が
@@ -100,7 +105,7 @@ gh label create "done"           --color "5319E7" --description "完了（corp a
    反映済みであることを確認。
 3. **done ラベル付与（auto-stop トリガー）**:
    ```bash
-   gh issue edit <N> --add-label "done"
+   gh issue edit "$ARGUMENTS" --remove-label "published" --add-label "done"
    ```
    `done` 付与で claude-hub の GoalWatcher がセッションを猶予後 auto-stop する（M3）。会長へ完了報告。
 

--- a/.claude/commands/article.md
+++ b/.claude/commands/article.md
@@ -1,0 +1,119 @@
+---
+name: "article"
+description: "corp dispatch 用 記事 goal playbook(convert-service): 執筆→下書き→[会長承認]→公開+クロスポスト→[会長close]→merge→done"
+version: "1.0"
+---
+
+# 記事 goal playbook（convert-service / M4・corp#52）
+
+引数: $ARGUMENTS（**Issue 番号**）
+
+corp 本社から `/article <Issue番号>` で dispatch される、QuickConv の SEO/集客記事制作フロー
+（convert-service の **明示 selector**。既定 selector は `devcycle`）。team_salary の article playbook と
+**同型**（同じフェーズ・ラベル・会長ゲート）だが、convert-service の記事資産・投稿フローに合わせる。
+
+## 責務分離（真実源: `docs/articles/README.md`）
+
+- **convert-service 配下**: 記事本体 `docs/articles/<NNN>-<slug>.md`（YAML frontmatter）＋画像、
+  Dev.to/Hashnode 投稿スクリプト（`tools/publish-{devto,hashnode}-<NNN>.mjs`・英語記事のクロスポスト）。
+- **`tools/team_salary` 配下（submodule）から流用**: note / Qiita / X / Threads / IG の投稿モジュール
+  （重複実装禁止）。
+
+## このコマンドの位置づけ（重要）
+
+- フェーズ間は **報告して待つ**。会長の承認/close で次フェーズへ進む（勝手に先へ進めない）。
+- 終端で `done` ラベルを打つと claude-hub の GoalWatcher がセッションを猶予後 auto-stop する（M3）。
+- dispatch は非対話前提。テーマ・ターゲットは Issue 本文から推論し、会長に都度質問しない。
+- `.env` 注入は `npx dotenv -e .env -- <cmd>` を使う（`set -a && . .env` 形式は使わない）。
+
+## フェーズラベル（corp 共有語彙・spec §8）
+
+| ラベル | 意味 | 会長の番か |
+|---|---|---|
+| `draft-returned` | 記事下書き（`published: false`）作成済み。会長の承認待ち | ✅ 会長 |
+| `published` | 各プラットフォームへ公開＋クロスポスト済み。会長の close 待ち | 部署 |
+| `done` | merge 済み・完了（auto-stop トリガー） | 終端 |
+
+### 前提: フェーズラベル事前作成（冪等）
+
+```bash
+gh label create "draft-returned" --color "FBCA04" --description "記事下書き作成済・会長承認待ち" --force
+gh label create "published"      --color "0E8A16" --description "公開+クロスポスト済・会長close待ち" --force
+gh label create "done"           --color "5319E7" --description "完了（corp auto-stop トリガー）" --force
+```
+
+## 自己修復ポリシー（全フェーズ共通）
+
+エラー発生時: 自動修正（3回まで）→ AgentTeams 招集 → 会長確認（最終手段）。
+
+---
+
+## Phase A: 執筆 → 下書き → 返却（→ `draft-returned`）
+
+1. **記事執筆**: `docs/articles/<NNN>-<slug>.md` を新規作成（連番は既存の最大 +1）。frontmatter は
+   `published: false`／`canonical_url: ""`／`platforms: {}`（空）で開始。本文はエビデンスに基づき執筆
+   （推論のみで数値を書かない）。
+2. **画像**: ヘッダ画像を `docs/articles/images/<NNN>-<slug>/` に生成・配置（frontmatter `cover_image`）。
+3. **下書き確認**: build を壊さないこと（`pnpm install --frozen-lockfile && pnpm run build`。pnpm 専用・
+   `npm install` 禁止＝RW-052）。記事はこの時点で **未公開**（`published: false`）。
+4. **フェーズラベル付与 + 報告 + 停止**:
+   ```bash
+   gh issue edit <N> --add-label "draft-returned"
+   gh issue comment <N> --body "## 下書き返却 - <timestamp>\n\n- 記事: docs/articles/<NNN>-<slug>.md（published:false）\n\n会長の承認をお待ちします（承認後に公開＋クロスポストへ進みます）。"
+   ```
+   会長へ下書き（記事パス・要旨）を報告し、**ここで停止して会長の承認発言を待つ**。
+
+---
+
+## Phase B: [会長承認] → 公開 + クロスポスト（→ `published`）
+
+会長から承認（「承認」「公開して」等）を受けてから実行する。
+
+1. **Dev.to / Hashnode（英語記事・convert-service 配下）**: 既存パターンに倣い
+   `tools/publish-{devto,hashnode}-<NNN>.mjs` を用意し実行する（必要 env: `DEVTO_API_KEY` /
+   `HASHNODE_TOKEN` / `HASHNODE_PUBLICATION_ID`）。
+   ```bash
+   npx dotenv -e .env -- node tools/publish-devto-<NNN>.mjs
+   npx dotenv -e .env -- node tools/publish-hashnode-<NNN>.mjs
+   ```
+2. **note / Qiita / SNS（`tools/team_salary` submodule を流用）**: submodule 側の投稿モジュールで
+   note / Qiita / X / Threads / IG へクロスポストする（`docs/articles/README.md` の流用方針に従う）。
+3. **frontmatter 更新**: `published: true`／`published_at`／`canonical_url`／`platforms.{devto,hashnode,
+   note,qiita,...}` に公開 URL を反映してコミットする。
+4. **フェーズラベル付与 + 報告 + 停止**:
+   ```bash
+   gh issue edit <N> --remove-label "draft-returned" --add-label "published"
+   ```
+   会長へ各プラットフォームの公開 URL を報告し、**会長の close を待つ**。
+   - いずれかの公開が失敗したら、そのプラットフォームを切り分けて再試行（自己修復ポリシー）。主要公開が
+     成立しないうちは `published` を付けない。
+
+---
+
+## Phase C: [会長 close] → merge → `done`
+
+会長が Issue を close（または「close」「完了」指示）したら実行する。
+
+1. **merge**: dispatch ブランチ（`corp-dispatch-<N>`）上の記事 `.md`・画像・frontmatter 更新・投稿スクリプトを
+   **PR 経由で main へ反映**（直 push 禁止・PR 必須）。PR があれば merge。
+2. **merge 漏れ確認**: `git status --porcelain` で未コミット変更が無いこと、frontmatter の公開 URL が
+   反映済みであることを確認。
+3. **done ラベル付与（auto-stop トリガー）**:
+   ```bash
+   gh issue edit <N> --add-label "done"
+   ```
+   `done` 付与で claude-hub の GoalWatcher がセッションを猶予後 auto-stop する（M3）。会長へ完了報告。
+
+---
+
+## 統合ジャーニーAC（spec §11 article 経路）
+
+| # | 操作 | 期待結果 | 検証手段 |
+|---|---|---|---|
+| 1 | corp が `/article <N>` を dispatch | 部署セッション起動→Phase A 実行→`docs/articles/<NNN>-<slug>.md`（published:false）作成＋`draft-returned` 付与 | 記事ファイル存在＋frontmatter `published: false`、`gh issue view <N>` に `draft-returned` |
+| 2 | 会長が承認発言 | Phase B 実行→Dev.to/Hashnode＋note/Qiita/SNS 公開→frontmatter `published: true`＋URL→`published` 付与 | 各 platform URL が HTTP 200、frontmatter `platforms` に URL、`gh issue view <N>` に `published` |
+| 3 | 会長が Issue を close | Phase C 実行→PR merge→`done` 付与→GoalWatcher が猶予後 auto-stop | `gh issue view <N>` に `done`、claude-hub で当該スレッドが archived |
+
+> 注: 会長ゲートを跨ぐため、フル E2E の決定的検証は corp からの実 dispatch 時にのみ可能。本 PR では
+> コマンド定義（フェーズ・ラベル・停止点・`docs/articles/README.md` の投稿フロー準拠）の正しさをレビューで
+> 担保する。

--- a/.claude/commands/devcycle.md
+++ b/.claude/commands/devcycle.md
@@ -74,7 +74,7 @@ gh label create "done"          --color "5319E7" --description "完了（corp au
      停止しない（`done` ラベルで停止する。AC-7）。早期 close を避けたい場合は PR 本文では参照のみに留める。
 5. **PR CI（`lint-and-build` ＋ `test`）が green** になったら:
    ```bash
-   gh issue edit <N> --add-label "staging-ready"
+   gh issue edit "$ARGUMENTS" --add-label "staging-ready"
    ```
    会長へ「実装＋PR 完了、CI green。レビューと merge をお願いします」と報告し、**会長の merge を待つ**。
 
@@ -93,7 +93,7 @@ gh label create "done"          --color "5319E7" --description "完了（corp au
 2. **判定**:
    - **`e2e-prod` まで green（本番デプロイ＋本番 E2E 成功）**:
      ```bash
-     gh issue edit <N> --remove-label "staging-ready" --add-label "deployed"
+     gh issue edit "$ARGUMENTS" --remove-label "staging-ready" --add-label "deployed"
      ```
      会長へ本番デプロイ完了＋本番 E2E green を報告し、**会長の close を待つ**。
    - **staging E2E or 本番 E2E が fail**: 本番デプロイはゲートで止まる（または本番後に検知）。原因を調査し
@@ -110,7 +110,7 @@ gh label create "done"          --color "5319E7" --description "完了（corp au
 2. **本番反映の最終確認**: `e2e-prod` が当該リリースで green であること（本番が壊れたまま done にしない）。
 3. **done ラベル付与（auto-stop トリガー）**:
    ```bash
-   gh issue edit <N> --add-label "done"
+   gh issue edit "$ARGUMENTS" --remove-label "deployed" --add-label "done"
    ```
    `done` 付与で claude-hub の GoalWatcher がセッションを猶予後 auto-stop する（M3）。会長へ完了報告。
 

--- a/.claude/commands/devcycle.md
+++ b/.claude/commands/devcycle.md
@@ -1,0 +1,133 @@
+---
+name: "devcycle"
+description: "corp dispatch 用 開発 goal playbook: 調査→実装→PR→[会長merge]→本番デプロイ→本番E2E→[会長close]→done（CI 自動パイプラインを会長ゲートで区切る）"
+version: "1.0"
+---
+
+# 開発 goal playbook（corp dispatch / M4・corp#52）
+
+引数: $ARGUMENTS（**Issue 番号**）
+
+corp 本社から `/devcycle <Issue番号>` で dispatch される開発の一連フロー（convert-service 既定 selector）。
+convert-service の **CI 自動パイプライン**（`.github/workflows/ci.yml`）を **会長ゲートで区切る多フェーズ手順**
+に束ね、各フェーズ末に GitHub フェーズラベルを打つ。このラベルを corp board（可視化）と claude-hub の
+auto-stop（GoalWatcher）が共有する。
+
+## このコマンドの位置づけ（重要）
+
+- corp dispatch の selector `devcycle`（convert-service 既定）に対応する slash コマンド。
+- フェーズ間は **報告して待つ**。会長の merge/close で次フェーズへ進む（勝手に先へ進めない）。
+- 終端で `done` ラベルを打つと claude-hub の GoalWatcher がセッションを猶予後 auto-stop する（M3）。
+- **CI が本番までの deploy/E2E を自動実行する**。本 playbook は手で deploy せず、CI の進行を監視して
+  ラベル付けと会長への報告・停止を行う。
+- **pnpm 専用**。`npm install` / `yarn install` は実行しない（package-lock を生成し CI の
+  `--frozen-lockfile` を壊す。RW-052）。依存は `pnpm install --frozen-lockfile`。
+
+## CI パイプライン（真実源: `.github/workflows/ci.yml`）
+
+| 契機 | 実行ジョブ |
+|---|---|
+| **PR** | `lint-and-build`（`pnpm run lint`/`build`/`format:check`）＋ `test`（vitest） |
+| **main へ push（merge）** | `deploy-stg`（Pages staging ＋ `apps/api` Workers staging）→ `e2e-stg`（Playwright @staging）→ `deploy-prod`（Pages 本番 ＋ Workers 本番・**staging E2E でゲート**）→ `e2e-prod`（Playwright @本番） |
+
+staging E2E が通らなければ本番デプロイは走らない（CI でゲート済み）。
+
+## フェーズラベル（corp 共有語彙・spec §8）
+
+| ラベル | 意味 | 会長の番か |
+|---|---|---|
+| `staging-ready` | PR 作成＋PR CI green。会長の merge 待ち | ✅ 会長 |
+| `deployed` | merge 後 CI が本番デプロイ＋本番 E2E まで green。会長の close 待ち | 部署 |
+| `done` | merge 漏れ確認済み・完了（auto-stop トリガー） | 終端 |
+
+`approved` は corp の dispatch ゲートラベルで進行フェーズではない（board は無視）。
+
+### 前提: フェーズラベル事前作成（冪等）
+
+```bash
+gh label create "staging-ready" --color "FBCA04" --description "PR CI green・会長merge待ち" --force
+gh label create "deployed"      --color "1D76DB" --description "本番デプロイ+本番E2E green・会長close待ち" --force
+gh label create "done"          --color "5319E7" --description "完了（corp auto-stop トリガー）" --force
+```
+
+## 自己修復ポリシー（全フェーズ共通）
+
+エラー発生時: 自動修正（3回まで）→ AgentTeams 招集 → 会長確認（最終手段）。
+
+---
+
+## Phase 1: 調査 → 実装 → PR（→ `staging-ready`）
+
+1. **調査**: Issue N の要件を把握。必要なら再現・原因特定（バグなら再現手順を確立）。
+2. **実装**: dispatch ブランチ（`corp-dispatch-N`）上で実装。`apps/{web,api,converter}` / `packages/shared`
+   の該当箇所を変更。
+3. **ローカル検証（PR 前）**:
+   ```bash
+   pnpm install --frozen-lockfile
+   pnpm run lint        # tsc 型チェック
+   pnpm run build       # turbo build
+   pnpm -r test         # vitest（変更パッケージ）
+   ```
+   UI 変更があれば任意で `cd apps/web && pnpm test:e2e`（ローカル Playwright）で事前確認。
+4. **PR 作成**（直 push 禁止・PR 必須）。本文に変更概要・テスト方法を記載。
+   - 注: PR 本文に `Closes #N` を付けると **merge で Issue が閉じる**が、本 playbook は Issue close では
+     停止しない（`done` ラベルで停止する。AC-7）。早期 close を避けたい場合は PR 本文では参照のみに留める。
+5. **PR CI（`lint-and-build` ＋ `test`）が green** になったら:
+   ```bash
+   gh issue edit <N> --add-label "staging-ready"
+   ```
+   会長へ「実装＋PR 完了、CI green。レビューと merge をお願いします」と報告し、**会長の merge を待つ**。
+
+---
+
+## Phase 2: [会長 merge] → 本番デプロイ → 本番 E2E（→ `deployed`）
+
+会長が PR を merge したら、CI が自動で `deploy-stg → e2e-stg → deploy-prod → e2e-prod` を走らせる。
+**手動 deploy はしない**。CI の進行を監視する。
+
+1. **CI 監視**:
+   ```bash
+   gh run watch "$(gh run list --branch main --workflow CI --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
+   ```
+   または `gh run list --branch main` で最新 run の `deploy-prod` / `e2e-prod` ジョブの成否を確認。
+2. **判定**:
+   - **`e2e-prod` まで green（本番デプロイ＋本番 E2E 成功）**:
+     ```bash
+     gh issue edit <N> --remove-label "staging-ready" --add-label "deployed"
+     ```
+     会長へ本番デプロイ完了＋本番 E2E green を報告し、**会長の close を待つ**。
+   - **staging E2E or 本番 E2E が fail**: 本番デプロイはゲートで止まる（または本番後に検知）。原因を調査し
+     修正 PR を出す（自己修復ポリシー）。`deployed` は付けず会長へ通知。
+
+---
+
+## Phase 3: [会長 close] → merge 漏れ確認 → `done`
+
+会長が Issue を close（または「close」「完了」指示）したら実行する。
+
+1. **merge 漏れ確認**: 当該 Issue に紐づく PR がすべて merge 済みで、`main` に未反映の変更が無いことを確認。
+   関連 follow-up（hotfix 等）があれば取りこぼしていないか点検する。
+2. **本番反映の最終確認**: `e2e-prod` が当該リリースで green であること（本番が壊れたまま done にしない）。
+3. **done ラベル付与（auto-stop トリガー）**:
+   ```bash
+   gh issue edit <N> --add-label "done"
+   ```
+   `done` 付与で claude-hub の GoalWatcher がセッションを猶予後 auto-stop する（M3）。会長へ完了報告。
+
+> **AC-7（重要）**: 本番 E2E は merge（Issue が `Closes #N` で閉じても）より後に走りうる。GoalWatcher は
+> Issue close ではなく `done` ラベルで停止するため、close 後も本番デプロイ＋本番 E2E が完走できる。
+> `done` は本番 E2E green を確認してから打つこと。
+
+---
+
+## 統合ジャーニーAC（spec §11 devcycle 経路）
+
+| # | 操作 | 期待結果 | 検証手段 |
+|---|---|---|---|
+| 1 | corp が `/devcycle <N>` を dispatch | 部署セッション起動→実装→PR 作成→PR CI green→`staging-ready` 付与 | `gh pr list` に PR、PR checks green、`gh issue view <N>` に `staging-ready` |
+| 2 | 会長が PR を merge | CI が deploy-stg→e2e-stg→deploy-prod→e2e-prod を完走→`deployed` 付与 | `gh run list --branch main` で `e2e-prod` success、`gh issue view <N>` に `deployed` |
+| 3 | 会長が Issue を close | merge 漏れ確認→`done` 付与→GoalWatcher が猶予後 auto-stop | `gh issue view <N>` に `done`、claude-hub で当該スレッドが archived |
+
+> 注: 会長ゲート（merge / close）と CI 自動パイプラインを跨ぐため、フル E2E の決定的検証は corp からの
+> 実 dispatch 時にのみ可能。本 PR ではコマンド定義（フェーズ・ラベル・停止点・参照する CI ジョブの実在）の
+> 正しさをレビューで担保する。


### PR DESCRIPTION
Closes #376

## 目的

corp #52 の **M4 = 部署 goal playbook** のうち convert-service 側。corp dispatch の selector に対応する slash コマンド 2 本を新設する。

- `.claude/commands/devcycle.md` — 既定 selector（開発フロー）
- `.claude/commands/article.md` — 明示 selector（SEO/集客記事フロー・team_salary 同型）

## なぜ `.claude/commands/`（issue は playbooks/ と記載）

claude-hub の dispatch parser（corp#52 M2 / #261）は selector を **slash コマンド** `/devcycle <N>` / `/article <N>` として注入する。Claude Code の slash コマンドは `.claude/commands/` から解決されるため invocable にするには `.claude/commands/` 必須。issue の `.claude/playbooks/` は M2 で slash コマンド契約が確定する前の記載。

## devcycle（既定）

convert-service の **CI 自動パイプライン**（`.github/workflows/ci.yml`: `deploy-stg → e2e-stg → deploy-prod → e2e-prod`）を会長ゲートで区切る。手動 deploy はせず CI 進行を監視してラベル付け。

| Phase | 内容 | 末尾ラベル | 停止（会長の番） |
|---|---|---|---|
| 1 | 調査→実装→PR（PR CI: lint/build/test green） | `staging-ready` | 会長の**merge**待ち |
| 2 | [merge] → CI 自動 stg deploy+E2E→**本番 deploy+E2E** | `deployed` | 会長の**close**待ち |
| 3 | [close] → merge 漏れ確認 | `done` | 終端（GoalWatcher auto-stop） |

- **AC-7**: 本番 E2E は merge（`Closes #N` で Issue が閉じても）より後に走る。GoalWatcher は Issue close ではなく `done` ラベルで停止するため、close 後も本番 E2E が完走できる。`done` は本番 E2E green 確認後に付与。
- **pnpm 専用**（`npm install` 禁止＝RW-052）。

## article（明示・team_salary 同型）

`docs/articles/<NNN>-<slug>.md` の frontmatter（`published`/`canonical_url`/`platforms`）を draft→publish で更新。`docs/articles/README.md` の責務分離に準拠：

- convert-service 配下: Dev.to/Hashnode（`tools/publish-{devto,hashnode}-<NNN>.mjs`）＋記事資産
- `tools/team_salary` submodule 流用: note/Qiita/X/Threads/IG

| Phase | 内容 | 末尾ラベル | 停止 |
|---|---|---|---|
| A | 執筆→下書き（`published:false`） | `draft-returned` | 会長の**承認**待ち |
| B | [承認]→公開+クロスポスト→frontmatter URL 反映 | `published` | 会長の**close**待ち |
| C | [close]→PR merge→merge 漏れ確認 | `done` | 終端 |

`.env` 注入は `npx dotenv -e .env -- <cmd>`（`set -a && . .env` 形式は使わない）。

## ラベル / 統合ジャーニーAC

- フェーズラベル文字列（`staging-ready`/`deployed`/`draft-returned`/`published`/`done`）は corp `src/board.ts` の `Phase` 語彙・claude-hub GoalWatcher の `done` トリガーと一致。
- 各 playbook 末尾に統合ジャーニーAC（spec §11 devcycle / article 経路）を記載。フル E2E の決定的検証は corp からの実 dispatch 時にのみ可能なため、本 PR ではコマンド定義（フェーズ・ラベル・停止点・参照 CI ジョブ/スクリプトの実在）の正しさをレビューで担保。

## テスト

- markdown command 定義のみ（実行コードなし）。参照先（ci.yml の deploy/e2e ジョブ、`apps/api` wrangler deploy、`docs/articles/README.md` の投稿フロー、`tools/team_salary` submodule）は origin/main に実在確認済み。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * 記事制作フローの手順書を追加し、段階別の承認ゲートと公開プロセスを定義
  * 開発ゴール実行用のプレイブックを追加し、開発から本番デプロイまでのワークフロー手順を記載

<!-- end of auto-generated comment: release notes by coderabbit.ai -->