### PR TITLE
ci: staging E2E メールを run/attempt ごとにユニーク化（429 マスキング解消・#383）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,10 +154,13 @@ jobs:
         env:
           E2E_TEST_SECRET: ${{ secrets.E2E_TEST_SECRET }}
         run: |
+          # メールを run/attempt ごとにユニーク化する。checkout API のレート制限 (10回/時/メール)
+          # が固定メールだと attempt を跨いで蓄積し、rerun が全件 429 になって真のエラーを隠すため (#383)
+          E2E_EMAIL="e2e+staging-${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}@quickconv.cc"
           RESPONSE=$(curl -sf --retry 3 -X POST "https://api-staging.quickconv.cc/api/test/token" \
             -H "Content-Type: application/json" \
             -H "X-E2E-Secret: ${E2E_TEST_SECRET}" \
-            -d '{"email":"e2e+staging@quickconv.cc","plan":"free"}') || { echo "::error::Failed to fetch E2E token"; exit 1; }
+            -d "{\"email\":\"${E2E_EMAIL}\",\"plan\":\"free\"}") || { echo "::error::Failed to fetch E2E token"; exit 1; }
           TOKEN=$(echo "$RESPONSE" | jq -r '.token')
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
             echo "::error::E2E token is empty or null"


### PR DESCRIPTION
## 概要

Issue #383（e2e-stg が Stripe checkout へ遷移せず決定的に失敗）の再発防止ハードニング。

## 真因と対応（環境側・実施済み）

- **真因**: staging Workers の `STRIPE_SECRET_KEY` に Stripe **CLI セッションキー**（90日期限、2026-07-03 失効）が設定されていた。失効後、checkout session 作成が全件 `Expired API Key provided` の 500 になった（Playwright trace で実測確定）
- **対応済み**: ダッシュボードの標準 test キー（無期限）へ `wrangler secret put STRIPE_SECRET_KEY --env staging` で差し替え

## 本 PR の変更（診断性の再発防止）

失敗調査中、checkout API のレート制限（**メール×時間キーで10回/時**）が固定メール `e2e+staging@quickconv.cc` に attempt を跨いで蓄積し、**rerun が全件 429 になって真のエラー（500）を隠していた**。

- e2e-stg の `Generate auth-state.json` ステップで、E2E メールを `e2e+staging-${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}@quickconv.cc` にユニーク化
- `/api/test/token` は任意メールを upsert するため既存フローに影響なし（`upsertE2ETestUser`）
- 効果: rerun/attempt ごとにレート制限バケットが分離され、429 マスキングが構造的に発生しなくなる

## 検証

- D1 実測: `checkout:e2e+staging@quickconv.cc:2026-07-04T17` / `T18` が count=10（green だった 6/22 は count=4）→ 蓄積の証拠
- キー差し替え後、run 28713834791 を rerun 中（クォータ窓リセット後の attempt 5）。e2e-stg green → deploy-prod 完走を確認次第、本 PR にコメントで結果を追記する

## 関連

- Closes #383
- 検出契機: PR #379 マージ後の main push run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ステージング環境のE2E認証トークン取得で、再実行時に同じメールアドレスが使われて失敗しやすくなる問題を改善しました。
  * 各実行ごとに一意なメールアドレスを使うようにし、重複による429エラーの発生を抑えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->