### PR TITLE
feat: Qodo pr-agent を 2 本目の PR レビュアーとして導入する

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,64 @@
+# Qodo Merge (pr-agent) — CodeRabbit と独立に併設する 2 本目の PR レビュー AI
+#
+# 仕組み: PR が open / reopen / ready_for_review されると、Qodo の pr-agent が
+#         自動で PR をレビューし、レビュー結果と code suggestion を PR 上に投稿する。
+#         PR コメントから `/review` `/improve` `/ask` 等のコマンドも実行できる。
+#
+# ── 必須セットアップ（これが無いとレビューは動かない）──────────────────────
+#   Settings > Secrets and variables > Actions > New repository secret に以下を追加:
+#     Name   = GEMINI_API_KEY
+#     Secret = <Google AI Studio の API キー>
+#   ※ GITHUB_TOKEN は GitHub Actions が自動発行するため追加不要。
+#   ※ 値はこのリポジトリでは扱わない（Secret 経由のみ）。
+#
+# ── なぜ Gemini API なのか ──────────────────────────────────────────────
+#   GitHub App の "Gemini Code Assist" は consumer（無料）版が 2026-07-17 に
+#   シャットダウンされ、無料でのレビューは不可能になった。
+#     出典: https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review
+#   一方、Google AI Studio の Gemini "API" は別製品で、Flash 系モデルの無料枠が
+#   継続している。そこで pr-agent の LLM として Gemini API を使い、
+#   無料のまま 2 本目のレビュアーを成立させる。
+#   無料枠にはレート上限がある: https://ai.google.dev/gemini-api/docs/rate-limits
+#
+# ── モデルの差し替え方 ──────────────────────────────────────────────────
+#   config.model の値は litellm の命名（`gemini/<model-id>`）に従う。
+#   利用可能な model-id は下記で確認できる（キーの値は出力しないこと）:
+#     curl -s "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY"
+#   API キーの env 名は pr-agent 公式の `GOOGLE_AI_STUDIO.GEMINI_API_KEY`。
+#     出典: https://docs.pr-agent.ai/usage-guide/changing_a_model/
+#   （env 名がドットを含むのは pr-agent の設定キー記法であり、POSIX の環境変数名
+#     制約とは別。agent-base PR #540 で実レビュー生成まで動作確認済み。）
+#
+# 注: uses の the-pr-agent/pr-agent は旧 qodo-ai/pr-agent の canonical リネーム先。
+name: PR Agent (Qodo)
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr_agent_job:
+    # Bot 起因のイベントには反応しない（レビュー無限ループ・無駄な起動の防止）
+    if: ${{ github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    name: Qodo pr-agent auto review
+    steps:
+      - name: PR Agent action step
+        id: pragent
+        uses: the-pr-agent/pr-agent@v0.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # --- モデル設定（Google AI Studio の Gemini API・無料枠）---
+          config.model: "gemini/gemini-3.7-flash"
+          config.fallback_models: '["gemini/gemini-3.5-flash", "gemini/gemini-2.5-flash"]'
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # --- 自動実行するツール ---
+          github_action_config.auto_review: "true"     # PR レビューを自動投稿
+          github_action_config.auto_improve: "true"    # code suggestion を自動投稿
+          github_action_config.auto_describe: "false"  # PR 説明は上書きしない（日本語の自記述を保持）


### PR DESCRIPTION
## 目的

CodeRabbit の無料枠（4 PR レビュー/時・200 files/時）が PDCA の PR 量産で枯渇し、「review limit reached」でレビューが落ちる事象への対処。**Qodo pr-agent を 2 本目のレビュアーとして追加**し、CodeRabbit が枯渇してもレビューが途切れないようにする。

LLM には Google AI Studio の **Gemini API 無料枠**を使うため、追加費用は発生しない。

## なぜ Gemini Code Assist ではないのか

GitHub App の Gemini Code Assist は **consumer（無料）版が 2026-07-17 にシャットダウン**され、無料でのレビューは不可能になった。

> July 17, 2026: the consumer version is shut down, and all code review activities performed by the app end.
> — https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review

一方 Google AI Studio の Gemini **API** は別製品で、Flash 系モデルの無料枠が継続している。pr-agent は litellm 経由で任意プロバイダを使えるため、これを LLM に指定する。

## 変更点

`.github/workflows/pr_agent.yml` を追加する。PR が open / reopen / ready_for_review されると pr-agent が自動レビューと code suggestion を投稿する。PR コメントの `/review` `/improve` `/ask` でも起動できる。

| 設定 | 値 |
|---|---|
| 主モデル | `gemini/gemini-3.7-flash` |
| fallback | `gemini/gemini-3.5-flash` → `gemini/gemini-2.5-flash` |
| API キー | `GOOGLE_AI_STUDIO.GEMINI_API_KEY` ← `secrets.GEMINI_API_KEY`（登録済み） |
| PR 説明の上書き | しない（`auto_describe: false`。日本語の自記述を保持） |

### 識別子の出典（推測で書いていないこと）

- **model id**: 実 API（`GET https://generativelanguage.googleapis.com/v1beta/models`）で 3 モデルとも `generateContent` 対応として実在を確認
- **env 名**: [pr-agent 公式ドキュメント](https://docs.pr-agent.ai/usage-guide/changing_a_model/)に `GOOGLE_AI_STUDIO.GEMINI_API_KEY` と明記

## 先行検証（agent-base PR #540）

同一設定を agent-base で先に検証し、**実レビューの生成まで確認済み**。

| 検証 | 実測 |
|---|---|
| workflow 実行 | run `32094857152` = success |
| レビュー投稿 | 本文 1707 bytes の実レビュー（ticket 適合性分析・工数見積・セキュリティ所見・具体指摘） |
| 旧障害の再発 | `Failed to generate code suggestions` は出ていない |

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | workflow が YAML として妥当で model / キー env が意図どおり | `ruby -ryaml` でパースし assert | 例外なし | `template YAML OK: gemini/gemini-3.7-flash` exit 0 | **PASS** |
| AC-2 | secret `GEMINI_API_KEY` が登録済み | `gh secret list` | 名前が存在 | 存在を確認 | **PASS** |
| AC-3 | 本 PR に Qodo が実レビューを投稿する | PR コメントを確認 | レビュー本文が付く | 本 PR で観測 | 検証中 |

## セキュリティ注記

- trigger は `pull_request`（`pull_request_target` ではない）。fork からの PR では secret が露出しない GitHub 既定の安全側挙動になる
- 権限は最小限（`contents: read` / `pull-requests: write` / `issues: write`）
- `the-pr-agent/pr-agent` はタグ `@v0.36.0` に pin（供給網安全と再現性）
- `push` ごとの再レビューは無料枠の消費を抑えるため無効（trigger に `synchronize` を含めない）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * プルリクエストの作成・再オープン・レビュー準備完了時に、自動レビューを実行できるようになりました。
  * コメントを通じたレビュー依頼にも対応し、変更内容へのコード提案を自動投稿します。
  * ボットによるイベントは対象外とし、不要な重複レビューを防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->