### PR TITLE
fix: project-dates.yml の無効トリガー projects_v2_item を除去し startup_failure を解消

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,27 @@
+name: Lint Workflows
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        # shellcheck integration is disabled: it flags pre-existing, intentional
+        # single-quoted GraphQL literals as false positives (SC2016). This job's
+        # job is catching invalid workflow files (e.g. unsupported `on:` triggers,
+        # the root cause of convert-service#374), which actionlint's core checks
+        # already cover without shellcheck.
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -shellcheck=
+        shell: bash

--- a/.github/workflows/project-dates.yml
+++ b/.github/workflows/project-dates.yml
@@ -1,12 +1,15 @@
 name: Project Roadmap Date Automation
 
+# NOTE: Start date automation (Issue moved to In Progress) is handled by
+# GitHub Projects' built-in Workflow ("Item added/Status changed → Set date")
+# instead of an Actions trigger. `projects_v2_item` is a Projects webhook
+# event and is NOT a supported Actions `on:` trigger — including it makes
+# this entire workflow file invalid, causing startup_failure on every push
+# (see convert-service#374).
+
 on:
-  issues:
-    types: [opened, edited, labeled]
   pull_request:
     types: [closed]
-  projects_v2_item:
-    types: [edited]
 
 permissions:
   issues: write
@@ -14,85 +17,6 @@ permissions:
   repository-projects: write
 
 jobs:
-  # Issue が In Progress に移動 → Start date をセット
-  set-start-date:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'projects_v2_item' && github.event.changes.field_value.field_node_id != ''
-    steps:
-      - name: Check if status changed to In Progress
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-        run: |
-          # Get the field that changed
-          FIELD_ID="${{ github.event.changes.field_value.field_node_id }}"
-          # Status field ID
-          STATUS_FIELD_ID="PVTSSF_lAHOAAnM1c4BRvU7zg_epRg"
-          # In Progress option ID
-          IN_PROGRESS_ID="47fc9ee4"
-
-          if [ "$FIELD_ID" != "$STATUS_FIELD_ID" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          NEW_VALUE="${{ github.event.changes.field_value.to.optionId }}"
-          if [ "$NEW_VALUE" != "$IN_PROGRESS_ID" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "skip=false" >> $GITHUB_OUTPUT
-          echo "item_id=${{ github.event.projects_v2_item.node_id }}" >> $GITHUB_OUTPUT
-
-      - name: Set Start Date
-        if: steps.check.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-        run: |
-          TODAY=$(date -u +%Y-%m-%d)
-          PROJECT_ID="PVT_kwHOAAnM1c4BRvU7"
-          START_DATE_FIELD_ID="PVTF_lAHOAAnM1c4BRvU7zg_epUs"
-          ITEM_ID="${{ steps.check.outputs.item_id }}"
-
-          gh api graphql -f query='
-            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
-              updateProjectV2ItemFieldValue(
-                input: {
-                  projectId: $projectId
-                  itemId: $itemId
-                  fieldId: $fieldId
-                  value: { date: $date }
-                }
-              ) {
-                projectV2Item { id }
-              }
-            }
-          ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" -f fieldId="$START_DATE_FIELD_ID" -f date="$TODAY"
-
-          echo "Set Start Date to $TODAY for item $ITEM_ID"
-
-          # Add in-progress label to the issue
-          ITEM_CONTENT=$(gh api graphql -f query='
-            query($itemId: ID!) {
-              node(id: $itemId) {
-                ... on ProjectV2Item {
-                  content {
-                    ... on Issue { number repository { nameWithOwner } }
-                  }
-                }
-              }
-            }
-          ' -f itemId="$ITEM_ID" --jq '.data.node.content' 2>/dev/null || true)
-
-          ISSUE_NUM=$(echo "$ITEM_CONTENT" | jq -r '.number // empty' 2>/dev/null || true)
-          ISSUE_REPO=$(echo "$ITEM_CONTENT" | jq -r '.repository.nameWithOwner // empty' 2>/dev/null || true)
-
-          if [ -n "$ISSUE_NUM" ] && [ -n "$ISSUE_REPO" ]; then
-            gh issue edit "$ISSUE_NUM" --add-label "in-progress" -R "$ISSUE_REPO" 2>/dev/null || true
-            echo "Added in-progress label to issue #$ISSUE_NUM"
-          fi
-
   # PR がマージ → 紐づく Issue の Target date をセット
   set-end-date:
     runs-on: ubuntu-latest
@@ -101,6 +25,7 @@ jobs:
       - name: Get linked issues and set Target Date
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           TODAY=$(date -u +%Y-%m-%d)
           PROJECT_ID="PVT_kwHOAAnM1c4BRvU7"
@@ -109,7 +34,6 @@ jobs:
           REPO="${{ github.repository }}"
 
           # Get linked issues from PR body (matches "Closes #XX", "Fixes #XX", "Resolves #XX")
-          PR_BODY="${{ github.event.pull_request.body }}"
           ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true)
 
           # Also check PR linked issues via API


### PR DESCRIPTION
## 概要

`.github/workflows/project-dates.yml` が無効な Webhook イベント `projects_v2_item` を `on:` に指定していたため、main への全 push で startup_failure（Invalid workflow file）となり、PR マージ時の `in-progress` ラベル自動除去・Target date セット・Status=Done 更新がすべて機能していなかった（Issue #374）。

## 主な変更点

- `.github/workflows/project-dates.yml`:
  - `projects_v2_item` トリガー（Actions未対応のWebhookイベント）を削除
  - 対応する `set-start-date` ジョブ（Actionsでは発火しえないdead job）を削除
  - 未使用の `issues:` トリガーを削除
  - `pull_request: [closed]` による `set-end-date` のみに整理
  - Start date 自動化は GitHub Projects v2 のビルトイン Workflow に委譲（コメントで明記）
  - `set-end-date` ジョブ内で `github.event.pull_request.body` を run スクリプトへ直接埋め込んでいた箇所を `env:` 経由に変更（script injection 対策）
- `.github/workflows/lint-workflows.yml`（新規）: `.github/workflows/**` 変更時のみ実行する actionlint ジョブを追加。Invalid workflow file（無効な `on:` イベント等）を merge 前に検知する。shellcheck 統合は既存ファイル内の意図的な GraphQL 文字列リテラル（SC2016 false positive）を避けるため無効化。

## テスト方法

```bash
# AC-1: ワークフローが valid（[events] カテゴリのエラーが無い）
actionlint .github/workflows/project-dates.yml
# → [events] エラーは解消（shellcheck info のみ残るが lint-workflows.yml では -shellcheck= で無効化）

# 新規ワークフローも含めて全体を検証
actionlint -shellcheck= .github/workflows/*.yml
# → exit 0
```

- AC-2（push で startup_failure しない）/ AC-3（PRマージで in-progress 除去 + Target date/Done）は本 PR の merge 後、CI 実行結果で確認する。

Closes #374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * GitHub Actionsワークフローの設定を自動検査する仕組みを追加しました。

* **改善**
  * GitHub Projectsでの開始日の自動設定を組み込みWorkflowに移行しました。
  * マージ済みPull Requestの終了日設定に関する処理を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->